### PR TITLE
Fix variable name typo in similarity_distance function

### DIFF
--- a/synalinks/src/optimizers/omega.py
+++ b/synalinks/src/optimizers/omega.py
@@ -139,7 +139,7 @@ async def similarity_distance(candidate1, candidate2, embedding_model=None, axis
     embeddings1 = np.normalize(embeddings1, axis=axis)
     embeddings2 = np.normalize(embeddings2, axis=axis)
     embeddings1 = np.mean(embeddings1, axis=0)
-    embeddings1 = np.mean(embeddings2, axis=0)
+    embeddings2 = np.mean(embeddings2, axis=0)
     similarity = (np.sum(embeddings1 * embeddings2, axis=axis) + 1) / 2
     return 1 - similarity
 


### PR DESCRIPTION
First off, thanks for building and sharing Synalinks! :)

---

Fixes incorrect variable assignment in `similarity_distance` function that causes all candidate distances to evaluate to ~0, breaking OMEGA's DNS mechanism.

Variable name typo at line 142:

Before:
```python
embeddings1 = np.mean(embeddings1, axis=0) # Line 141
embeddings1 = np.mean(embeddings2, axis=0) # Line 142
```

After:
```python
embeddings1 = np.mean(embeddings1, axis=0) # Line 141
embeddings2 = np.mean(embeddings2, axis=0) # Line 142
```

One-character fix to assign to the correct variable!