### PR TITLE
Refresh LiteLLM async client for Ollama embeddings

### DIFF
--- a/synalinks/src/embedding_models/embedding_model.py
+++ b/synalinks/src/embedding_models/embedding_model.py
@@ -16,6 +16,34 @@ from synalinks.src.saving.synalinks_saveable import SynalinksSaveable
 litellm.disable_aiohttp_transport = True
 
 
+def _refresh_litellm_client():
+    """Refresh LiteLLM's shared async client for local embedding backends.
+
+    Ollama-backed embedding calls can fail with ``Event loop is closed`` when
+    LiteLLM reuses a pooled module-level client across loop boundaries.
+    """
+    try:
+        import httpx
+    except ImportError:
+        warnings.warn(
+            "Could not import httpx to refresh LiteLLM async client.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return
+
+    try:
+        litellm.module_level_aclient = httpx.AsyncClient(
+            limits=httpx.Limits(max_keepalive_connections=0, max_connections=100),
+        )
+    except Exception as e:
+        warnings.warn(
+            f"Could not refresh LiteLLM async client: {e!r}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
 @synalinks_export(
     [
         "synalinks.EmbeddingModel",
@@ -116,6 +144,8 @@ class EmbeddingModel(SynalinksSaveable):
             self.api_base = "http://localhost:11434"
         else:
             self.api_base = api_base
+        if self.model.startswith("ollama"):
+            _refresh_litellm_client()
         self.retry = retry
         self.fallback = fallback
         self.caching = caching

--- a/synalinks/src/embedding_models/embedding_model_test.py
+++ b/synalinks/src/embedding_models/embedding_model_test.py
@@ -1,6 +1,9 @@
 # License Apache 2.0: (c) 2025 Yoan Sallami (Synalinks Team)
 
 from unittest.mock import patch
+from unittest.mock import sentinel
+
+import litellm
 
 from synalinks.src import testing
 from synalinks.src.backend import Embeddings
@@ -8,6 +11,31 @@ from synalinks.src.embedding_models.embedding_model import EmbeddingModel
 
 
 class EmbeddingModelTest(testing.TestCase):
+    @patch("httpx.AsyncClient")
+    def test_ollama_model_refreshes_litellm_async_client(self, mock_async_client):
+        previous_client = getattr(litellm, "module_level_aclient", None)
+        self.addCleanup(setattr, litellm, "module_level_aclient", previous_client)
+        mock_async_client.return_value = sentinel.client
+
+        EmbeddingModel(model="ollama/nomic-embed-text")
+
+        self.assertIs(litellm.module_level_aclient, sentinel.client)
+        mock_async_client.assert_called_once()
+        limits = mock_async_client.call_args.kwargs["limits"]
+        self.assertEqual(limits.max_keepalive_connections, 0)
+        self.assertEqual(limits.max_connections, 100)
+
+    @patch("httpx.AsyncClient")
+    def test_non_ollama_model_keeps_existing_async_client(self, mock_async_client):
+        previous_client = getattr(litellm, "module_level_aclient", None)
+        self.addCleanup(setattr, litellm, "module_level_aclient", previous_client)
+        litellm.module_level_aclient = sentinel.previous_client
+
+        EmbeddingModel(model="gemini/text-embedding-004")
+
+        self.assertIs(litellm.module_level_aclient, sentinel.previous_client)
+        mock_async_client.assert_not_called()
+
     @patch("litellm.aembedding")
     async def test_call_api(self, mock_embedding):
         embedding_model = EmbeddingModel(model="ollama/all-minilm")


### PR DESCRIPTION
## Summary

This PR refreshes LiteLLM's module-level async client when `EmbeddingModel` is used with `ollama/*` models.

Without this, Ollama-backed embedding calls can fail in KnowledgeBase flows with:

```text
litellm.APIConnectionError: Event loop is closed
```

The fix replaces the shared async client with a no-keepalive `httpx.AsyncClient`, which matches the workaround already validated downstream.

## Changes

- add `_refresh_litellm_client()` in `embedding_model.py`
- call it only for `ollama/*` models in `EmbeddingModel.__init__`
- add tests to verify:
  - Ollama models refresh the shared async client
  - non-Ollama models are unchanged

## Validation

Unit tests:

```bash
PYTHONPATH=/home/utilisateur/g2i/Integration/PPasero-IGH-01/90128628379/synalinks-pr3 \
/home/utilisateur/g2i/Integration/PPasero-IGH-01/90128628379/.venv/bin/python \
-m pytest -o addopts='' \
/home/utilisateur/g2i/Integration/PPasero-IGH-01/90128628379/synalinks-pr3/synalinks/src/embedding_models/embedding_model_test.py -q
```

Result:

```text
6 passed in 9.26s
```

Real Ollama smoke tests on the local machine:

- `curl http://127.0.0.1:11434/api/tags` -> daemon running, `nomic-embed-text:latest` available
- direct embedding request to Ollama -> OK
- `synalinks.EmbeddingModel(model="ollama/nomic-embed-text", api_base="http://127.0.0.1:11434")` -> two embedding calls OK

Behavior before patch on installed Synalinks:

- simple embedding calls could pass
- `KnowledgeBase(..., embedding_model=EmbeddingModel(...))`
- `kb.update(...)`
- `kb.similarity_search(...)`
- failed with `litellm.APIConnectionError: Event loop is closed`

Behavior after patch on this branch:

- same `KnowledgeBase + similarity_search` smoke test passes and returns one row

## Scope

This only affects `ollama/*` embedding models. Other providers keep the existing LiteLLM client behavior.
