### PR TITLE
Fix AttributeError on sampling_temperature for non-Greedy optimizers

### DIFF
--- a/synalinks/src/optimizers/evolutionary_optimizer_test.py
+++ b/synalinks/src/optimizers/evolutionary_optimizer_test.py
@@ -190,3 +190,36 @@ class EvolutionaryOptimizerTest(testing.TestCase):
         ]
         result = optimizer.select_candidate(candidates)
         self.assertIn(result, candidates)
+
+    def test_sampling_temperature_default(self):
+        """EvolutionaryOptimizer must inherit `sampling_temperature` from the
+        base `Optimizer`, since `Optimizer.select_variable_name_to_update`
+        reads it. Before the fix, accessing this attribute on an
+        EvolutionaryOptimizer / OMEGA instance raised AttributeError."""
+        optimizer = EvolutionaryOptimizer()
+        self.assertEqual(optimizer.sampling_temperature, 0.3)
+
+    async def test_select_variable_name_to_update_does_not_raise(self):
+        """Regression test: `select_variable_name_to_update` on an
+        EvolutionaryOptimizer used to raise
+        `AttributeError: 'EvolutionaryOptimizer' object has no attribute
+        'sampling_temperature'`. It must now run and return a valid name."""
+        optimizer = EvolutionaryOptimizer()
+
+        class _Var:
+            def __init__(self, name, nb_visit, cumulative_reward):
+                self.name = name
+                self._d = {
+                    "nb_visit": nb_visit,
+                    "cumulative_reward": cumulative_reward,
+                }
+
+            def get(self, key):
+                return self._d[key]
+
+        variables = [
+            _Var("v0", nb_visit=1, cumulative_reward=0.5),
+            _Var("v1", nb_visit=1, cumulative_reward=0.2),
+        ]
+        name = await optimizer.select_variable_name_to_update(variables)
+        self.assertIn(name, {"v0", "v1"})

--- a/synalinks/src/optimizers/optimizer.py
+++ b/synalinks/src/optimizers/optimizer.py
@@ -37,6 +37,11 @@ class Optimizer(SynalinksSaveable):
     Args:
         population_size (int): The maximum number of best candidates to keep
             during the optimization process.
+        sampling_temperature (float): The temperature for softmax sampling of
+            which trainable variable to update at each step in
+            `select_variable_name_to_update`. Lower values concentrate updates
+            on under-visited / low-reward variables, higher values make the
+            choice more uniform (Default 0.3).
         name (str): Optional. The name of the optimizer.
         description (str): Optional. The description of the optimizer.
     """
@@ -44,6 +49,7 @@ class Optimizer(SynalinksSaveable):
     def __init__(
         self,
         population_size=10,
+        sampling_temperature=0.3,
         name=None,
         description=None,
         **kwargs,
@@ -55,6 +61,8 @@ class Optimizer(SynalinksSaveable):
         Args:
             population_size (int): The maximum number of best candidates to keep
                 during the optimization process.
+            sampling_temperature (float): The temperature for softmax sampling
+                of which trainable variable to update at each step.
             name (str): Optional name for the optimizer instance
             description (str): Optional description for the optimizer
             **kwargs (keyword params): Additional arguments (will raise error if provided)
@@ -68,6 +76,7 @@ class Optimizer(SynalinksSaveable):
             raise ValueError(f"Argument(s) not recognized: {kwargs}")
 
         self.population_size = population_size
+        self.sampling_temperature = sampling_temperature
 
         if name is None:
             name = auto_name(self.__class__.__name__)


### PR DESCRIPTION
## Summary

`Optimizer.select_variable_name_to_update` (base class) reads `self.sampling_temperature` at [`optimizer.py:261`](https://github.com/SynaLinks/synalinks/blob/main/synalinks/src/optimizers/optimizer.py#L261), but the attribute is only set by `GreedyOptimizer.__init__`. Every other `Optimizer` subclass — notably `EvolutionaryOptimizer` and its concrete child `OMEGA` — crashes with:

```
AttributeError: 'OMEGA' object has no attribute 'sampling_temperature'.
Did you mean: 'mutation_temperature'?
```

The regression was introduced in commit `bcc114c` *"finalize OMEGA"*, which added `self.sampling_temperature` at the base-class call site without promoting it to `Optimizer.__init__`. It escaped unit tests because nothing in the existing suite exercises `select_variable_name_to_update` on an evolutionary optimizer.

## Minimal repro (pre-fix)

```python
import asyncio, synalinks

class _Var:
    def __init__(self, name, nb_visit, cumulative_reward):
        self.name = name
        self._d = {"nb_visit": nb_visit, "cumulative_reward": cumulative_reward}
    def get(self, k): return self._d[k]

async def main():
    opt = synalinks.optimizers.OMEGA(
        language_model=synalinks.LanguageModel(model="ollama/mistral"),
        embedding_model=synalinks.EmbeddingModel(model="ollama/nomic-embed-text"),
    )
    variables = [_Var("v0", 1, 0.5), _Var("v1", 1, 0.2)]
    print(await opt.select_variable_name_to_update(variables))

asyncio.run(main())
```

**Before:**
```
File \".../synalinks/src/optimizers/optimizer.py\", line 261, in select_variable_name_to_update
    scaled_rewards = inverted_rewards / self.sampling_temperature
AttributeError: 'OMEGA' object has no attribute 'sampling_temperature'. Did you mean: 'mutation_temperature'?
```

**After:**
```
SELECTED=v1
```

This also blocks any `await program.fit(...)` call that compiles with `OMEGA` — the crash fires on the first step, before any candidate is proposed.

## Fix

Promote `sampling_temperature` to `Optimizer.__init__` (default `0.3`, same default `GreedyOptimizer` already ships with). This is the class where the method consuming the attribute is defined, so it's the natural location.

- `GreedyOptimizer` keeps its explicit `sampling_temperature` kwarg and `self.sampling_temperature = sampling_temperature` override → 100% backward compatible.
- `EvolutionaryOptimizer` / `OMEGA` now inherit the attribute with a sane default.
- Zero rename, zero API break.

Diff: **+42/−0**, 2 files.

## Tests

Added two regression tests in `evolutionary_optimizer_test.py`:

- `test_sampling_temperature_default` — asserts the attribute now exists on `EvolutionaryOptimizer` with default `0.3`.
- `test_select_variable_name_to_update_does_not_raise` — exercises the exact code path that used to raise, with realistic `nb_visit` / `cumulative_reward` state.

Full optimizers suite green:

```
$ uv run pytest synalinks/src/optimizers/ -o addopts=''
42 passed in 64.23s
```

Trainers suite unaffected:

```
$ uv run pytest synalinks/src/trainers/ -o addopts=''
14 passed in 4.27s
```

## Scope

Strictly the `sampling_temperature` regression. Does not touch `EvolutionaryOptimizer`, `GreedyOptimizer`, `OMEGA`, or any subclass API. No rename.

There are two separate follow-up issues I'd like to send in their own PRs after this one lands (happy to discuss approach before writing them):

1. `EmbeddingModel.__call__` rejects non-string leaves produced by `tree.flatten(candidate)` at [`omega.py:169`](https://github.com/SynaLinks/synalinks/blob/main/synalinks/src/optimizers/omega.py#L169), which breaks `OMEGA.fit()` even with this PR applied.
2. `trainer.py` references `val_x` unconditionally when `validation_split=0.0`, giving `UnboundLocalError`.

Both are distinct regressions and will stay out of this PR.