### PR TITLE
fix(duckdb): resolve $ref/$defs for Enum and nested DataModel fields

### DIFF
--- a/synalinks/src/knowledge_bases/database_adapters/database_adapter_test.py
+++ b/synalinks/src/knowledge_bases/database_adapters/database_adapter_test.py
@@ -394,6 +394,128 @@ class DuckDBAdapterSchemaConversionTest(testing.TestCase):
         self.assertIsNotNone(retrieved)
         self.assertEqual(retrieved.get_json()["metadata"], {"key": "value", "count": 42})
 
+    def test_json_schema_to_duckdb_columns_with_str_enum(self):
+        """Pydantic emits `$ref` + `$defs` for bare `str, Enum` fields.
+
+        Before the fix, DuckDBAdapter raised
+        `ValueError: Malformed JSON schema: missing type for '<field>'`.
+        """
+        from enum import Enum
+
+        class Status(str, Enum):
+            OK = "ok"
+            KO = "ko"
+
+        class Record(DataModel):
+            id: str
+            status: Status
+
+        adapter = DuckDBAdapter(uri=self.db_path)
+        columns = adapter._json_schema_to_duckdb_columns(Record.get_schema())
+
+        self.assertIn("id VARCHAR PRIMARY KEY", columns)
+        self.assertIn("status VARCHAR", columns)
+
+    def test_json_schema_to_duckdb_columns_with_int_enum(self):
+        """IntEnum emits `type: integer` inside `$defs` — must become INTEGER."""
+        from enum import IntEnum
+
+        class Priority(IntEnum):
+            LOW = 1
+            HIGH = 2
+
+        class Task(DataModel):
+            id: str
+            priority: Priority
+
+        adapter = DuckDBAdapter(uri=self.db_path)
+        columns = adapter._json_schema_to_duckdb_columns(Task.get_schema())
+
+        self.assertIn("id VARCHAR PRIMARY KEY", columns)
+        # IntEnum → integer column
+        self.assertTrue(
+            "priority INTEGER" in columns or "priority BIGINT" in columns,
+            f"Expected integer column for IntEnum, got: {columns}",
+        )
+
+    def test_json_schema_to_duckdb_columns_with_optional_enum(self):
+        """Optional[Enum] emits anyOf with `$ref` + null — must resolve."""
+        from enum import Enum
+        from typing import Optional
+
+        class Color(str, Enum):
+            RED = "red"
+            BLUE = "blue"
+
+        class Item(DataModel):
+            id: str
+            color: Optional[Color] = None
+
+        adapter = DuckDBAdapter(uri=self.db_path)
+        columns = adapter._json_schema_to_duckdb_columns(Item.get_schema())
+
+        self.assertIn("id VARCHAR PRIMARY KEY", columns)
+        self.assertIn("color VARCHAR", columns)
+
+    def test_json_schema_to_duckdb_columns_with_nested_datamodel(self):
+        """Nested DataModel emits `$ref` resolving to `type: object` — JSON column."""
+
+        class Address(DataModel):
+            city: str
+            zip_code: str
+
+        class Person(DataModel):
+            id: str
+            address: Address
+
+        adapter = DuckDBAdapter(uri=self.db_path)
+        columns = adapter._json_schema_to_duckdb_columns(Person.get_schema())
+
+        self.assertIn("id VARCHAR PRIMARY KEY", columns)
+        # Nested object → JSON column (objects are stored as JSON)
+        self.assertIn("address JSON", columns)
+
+    async def test_crud_with_str_enum_roundtrip(self):
+        """End-to-end roundtrip: insert then SELECT must preserve enum value."""
+        from enum import Enum
+
+        class Role(str, Enum):
+            ADMIN = "admin"
+            USER = "user"
+
+        class Account(DataModel):
+            id: str
+            role: Role
+
+        adapter = DuckDBAdapter(uri=self.db_path)
+        account = Account(id="acc1", role=Role.ADMIN)
+        json_dm = JsonDataModel(data_model=account)
+
+        result = await adapter.update(json_dm)
+        self.assertEqual(result, "acc1")
+
+        retrieved = await adapter.get("acc1", [Account.to_symbolic_data_model()])
+        self.assertIsNotNone(retrieved)
+        self.assertEqual(retrieved.get_json()["role"], "admin")
+
+    def test_json_schema_to_duckdb_columns_preserves_description_on_ref(self):
+        """When the referring property has `description`, it must not disappear
+        after `$ref` resolution — protects metadata the user attaches via
+        `Field(description=...)` on enum fields."""
+        from enum import Enum
+
+        class Status(str, Enum):
+            OK = "ok"
+
+        class Record(DataModel):
+            id: str
+            status: Status = Field(description="The record status.")
+
+        adapter = DuckDBAdapter(uri=self.db_path)
+        # Must not raise
+        columns = adapter._json_schema_to_duckdb_columns(Record.get_schema())
+        self.assertIn("status VARCHAR", columns)
+
 
 class DuckDBAdapterFulltextSearchTest(testing.TestCase):
     def setUp(self):

--- a/synalinks/src/knowledge_bases/database_adapters/duckdb_adapter.py
+++ b/synalinks/src/knowledge_bases/database_adapters/duckdb_adapter.py
@@ -299,30 +299,52 @@ class DuckDBAdapter(DatabaseAdapter):
         Uses the first property as the primary key.
         """
         properties = json_schema.get("properties", {})
+        defs = json_schema.get("$defs", {})
         out = []
         first_col = True
 
         for prop_name, prop_spec in properties.items():
             prop_name = sanitize_identifier(prop_name)
+
+            # Resolve $ref (Pydantic v2 emits these for enum.Enum and
+            # nested BaseModel fields). Preserve sibling keys like
+            # `description` from the referring property.
+            if "$ref" in prop_spec:
+                ref_name = prop_spec["$ref"].rsplit("/", 1)[-1]
+                if ref_name in defs:
+                    resolved = dict(defs[ref_name])
+                    resolved.update({k: v for k, v in prop_spec.items() if k != "$ref"})
+                    prop_spec = resolved
+
             prop_type = prop_spec.get("type")
 
             if prop_name == self.vss_key:
                 continue
 
-            # Handle anyOf schemas (e.g. Optional[datetime] from Pydantic)
+            # Handle anyOf schemas (e.g. Optional[datetime] or Optional[Enum])
             if not prop_type and "anyOf" in prop_spec:
                 for variant in prop_spec["anyOf"]:
+                    # Resolve $ref inside anyOf variants too
+                    if "$ref" in variant:
+                        ref_name = variant["$ref"].rsplit("/", 1)[-1]
+                        if ref_name in defs:
+                            variant = defs[ref_name]
                     vtype = variant.get("type")
                     if vtype and vtype != "null":
                         prop_type = vtype
                         prop_spec = variant
                         break
+                    if "enum" in variant:
+                        prop_type = "string"
+                        break
+
+            # Bare enum without explicit type (older Pydantic or non-typed
+            # Enum subclasses emit {"enum": [...]} with no "type").
+            if not prop_type and "enum" in prop_spec:
+                prop_type = "string"
 
             if not prop_type:
-                raise ValueError(
-                    f"Malformed JSON schema: "
-                    f"missing type for '{prop_name}'"
-                )
+                raise ValueError(f"Malformed JSON schema: missing type for '{prop_name}'")
 
             col_def = None
 


### PR DESCRIPTION
## Problem

Pydantic v2 emits `$ref` references pointing into `$defs` for `enum.Enum`
and nested `BaseModel` fields. `DuckDBAdapter._json_schema_to_duckdb_columns`
reads `prop_spec.get("type")` directly, which returns `None` for any
`$ref` property, and raises:

```
ValueError: Malformed JSON schema: missing type for '<field>'
```

Any `synalinks.KnowledgeBase` user who declares an `Enum` field in a
DataModel hits this — and `Enum` is an idiomatic, documented synalinks
pattern (see [references/data-models.md](https://github.com/SynaLinks/synalinks/blob/main/.claude/skills/synalinks/references/data-models.md) and `Decision` modules that use labels).

## Minimal 100%-synalinks-native repro (on `main` @ aaaa4ec)

```python
import asyncio, tempfile
from enum import Enum
from pathlib import Path
import synalinks

class Status(str, Enum):
    OK = "ok"; KO = "ko"

@synalinks.saving.register_synalinks_serializable(package="repro")
class Record(synalinks.DataModel):
    id: str = synalinks.Field(description="Primary key.")
    status: Status = synalinks.Field(description="Record status.")

async def main():
    with tempfile.TemporaryDirectory() as tmp:
        synalinks.KnowledgeBase(
            uri=f"duckdb://{Path(tmp)/'r.db'}",
            data_models=[Record],
            embedding_model=None,
        )

asyncio.run(main())
# !! ValueError: Malformed JSON schema: missing type for 'status'
```

The emitted schema:
```json
{
  "$defs": {"Status": {"enum": ["ok", "ko"], "type": "string", ...}},
  "properties": {
    "id":     {"type": "string", ...},
    "status": {"$ref": "#/$defs/Status", "description": "Record status."}
  }
}
```

## Fix

Resolve `$ref` into `$defs` before reading `type`, preserving sibling
keys (e.g. `description` from `synalinks.Field`) on the referring
property. Also handle:

- `$ref` inside `anyOf` variants (`Optional[Enum]`)
- bare `{"enum": [...]}` without explicit `type` (fallback to `string`)

**Scope**: single point of fix in `_json_schema_to_duckdb_columns`
(+17 lines). I audited all 10+ other sites that call
`data_model.get_schema()` — they only read property **names** (via
`_get_id_key` / `_get_fts_field`), never types, so they are unaffected
by `$ref`.

## Tests

Added 6 tests covering edge cases, all green:

- `test_json_schema_to_duckdb_columns_with_str_enum` — `class X(str, Enum)`
- `test_json_schema_to_duckdb_columns_with_int_enum` — `IntEnum` → `INTEGER`
- `test_json_schema_to_duckdb_columns_with_optional_enum` — `Optional[Enum]` (`anyOf` null + `\$ref`)
- `test_json_schema_to_duckdb_columns_with_nested_datamodel` — nested `DataModel` → JSON column
- `test_crud_with_str_enum_roundtrip` — insert + `get` preserves enum value
- `test_json_schema_to_duckdb_columns_preserves_description_on_ref` — `Field(description=...)` on enum field

**Test results on this branch**:
- `database_adapter_test.py`: 39/39 (33 existing + 6 new)
- `knowledge_bases/` + `optimizers/` + `trainers/`: 98/98

## Backward compatibility

Schemas without `$ref` go through the original code path unchanged (the
`if "$ref" in prop_spec:` check guards the resolution).

## Related

Found while integrating synalinks into a pipeline with domain enums
(`FeatureClass`, `OmicsType`, etc.). Bug also reported informally for
users of `synalinks.Decision`-like patterns where the label set is
modeled as an Enum.