### PR TITLE
fix(trainer): handle None validation_data in fit()

### DIFF
--- a/synalinks/src/optimizers/optimizer.py
+++ b/synalinks/src/optimizers/optimizer.py
@@ -548,24 +548,30 @@ class Optimizer(SynalinksSaveable):
             training=True,
         )
 
-        y_pred = await self.program.predict_on_batch(
-            x=val_x,
-            training=False,
-        )
-
-        rewards = await self.program.compute_reward(
-            x=val_x,
-            y=val_y,
-            y_pred=y_pred,
-        )
-
-        if self.trainable_variables:
-            await self.assign_reward_to_predictions(
-                self.trainable_variables,
-                rewards=rewards,
+        if val_x is not None:
+            val_y_pred = await self.program.predict_on_batch(
+                x=val_x,
+                training=False,
             )
 
-        mean_reward = float(sum(rewards) / len(rewards))
+            val_rewards = await self.program.compute_reward(
+                x=val_x,
+                y=val_y,
+                y_pred=val_y_pred,
+            )
+
+            if self.trainable_variables:
+                await self.assign_reward_to_predictions(
+                    self.trainable_variables,
+                    rewards=val_rewards,
+                )
+
+            mean_reward = float(sum(val_rewards) / len(val_rewards))
+        else:
+            # No validation data — use training rewards for candidate selection
+            val_y_pred = y_pred
+            mean_reward = float(sum(rewards) / len(rewards))
+
         for trainable_variable in trainable_variables:
             await self.maybe_add_candidate(
                 step,
@@ -574,7 +580,12 @@ class Optimizer(SynalinksSaveable):
             )
 
         await self.reward_tracker.update_state(mean_reward)
-        metrics = await self.program.compute_metrics(val_x, val_y, y_pred)
+        if val_x is not None:
+            metrics = await self.program.compute_metrics(
+                val_x, val_y, val_y_pred
+            )
+        else:
+            metrics = await self.program.compute_metrics(x, y, val_y_pred)
         return metrics
 
     async def propose_new_candidates(

--- a/synalinks/src/trainers/trainer.py
+++ b/synalinks/src/trainers/trainer.py
@@ -458,7 +458,7 @@ class Trainer:
         """
         self._assert_compile_called("fit")
         self._eval_epoch_iterator = None
-        val_y, val_y = None, None
+        val_x, val_y = None, None
 
         if validation_split and validation_data is None:
             # Create the validation data using the training data. Only supported
@@ -552,7 +552,7 @@ class Trainer:
 
                     mini_val_x = None
                     mini_val_y = None
-                    if minibatch_size:
+                    if minibatch_size and val_x is not None:
                         if len(val_x) > minibatch_size:
                             indices = np.random.choice(
                                 len(val_x),
@@ -571,14 +571,17 @@ class Trainer:
                         return_dict=True,
                     )
 
-                    val_logs = await self.evaluate(
-                        x=val_x,
-                        y=val_y,
-                        batch_size=validation_batch_size or batch_size,
-                        steps=validation_steps,
-                        callbacks=callbacks,
-                        _use_cached_eval_dataset=False,
-                    )
+                    if val_x is not None:
+                        val_logs = await self.evaluate(
+                            x=val_x,
+                            y=val_y,
+                            batch_size=validation_batch_size or batch_size,
+                            steps=validation_steps,
+                            callbacks=callbacks,
+                            _use_cached_eval_dataset=False,
+                        )
+                    else:
+                        val_logs = {}
 
                     if self.trainable_variables and isinstance(
                         self.optimizer, optimizers_module.Optimizer
@@ -886,15 +889,17 @@ class Trainer:
             )
         else:
             warnings.warn("The program does not have any trainable variables.")
-            y_pred = await self.predict_on_batch(val_x)
+            eval_x = val_x if val_x is not None else x
+            eval_y = val_y if val_y is not None else y
+            y_pred = await self.predict_on_batch(eval_x)
             rewards = await self.compute_reward(
-                x=val_x,
-                y=val_y,
+                x=eval_x,
+                y=eval_y,
                 y_pred=y_pred,
             )
             mean_reward = float(numpy.mean(rewards))
             await self._reward_tracker.update_state(mean_reward)
-            metrics = await self.compute_metrics(val_x, val_y, y_pred)
+            metrics = await self.compute_metrics(eval_x, eval_y, y_pred)
 
         if return_dict:
             return metrics

--- a/synalinks/src/trainers/trainer_test.py
+++ b/synalinks/src/trainers/trainer_test.py
@@ -14,6 +14,8 @@ from synalinks.src.language_models import LanguageModel
 from synalinks.src.testing.test_utils import AnswerWithRationale
 from synalinks.src.testing.test_utils import Query
 from synalinks.src.testing.test_utils import load_test_data
+from synalinks.src.testing.test_utils import mock_completion_data
+from synalinks.src.testing.test_utils import mock_incorrect_completion_data
 from synalinks.src.trainers.trainer import Trainer
 
 
@@ -174,3 +176,45 @@ class TestTrainer(testing.TestCase):
         self.assertEqual(len(y_data), len(x_train))
         self.assertIsInstance(y_data[0], JsonDataModel)
         self.assertIsInstance(y_data[1], JsonDataModel)
+
+    @patch("litellm.acompletion")
+    async def test_fit_without_validation_data(self, mock_completion):
+        """`fit()` must not crash when validation_split=0 and validation_data=None.
+
+        Regression test: previously `val_x` / `val_y` stayed `None` and were passed
+        unconditionally to `predict_on_batch`, `evaluate`, and `compute_metrics`,
+        raising at runtime.
+        """
+        inputs = modules.Input(data_model=Query)
+        outputs = await modules.Generator(
+            language_model=LanguageModel(model="ollama/mistral"),
+            data_model=AnswerWithRationale,
+        )(inputs)
+        program = programs.Program(
+            inputs=inputs,
+            outputs=outputs,
+            name="fit_no_val",
+            description="Fit without validation data",
+        )
+        program.compile(
+            optimizer=optimizers.random_few_shot.RandomFewShot(nb_min_examples=1),
+            reward=rewards.ExactMatch(in_mask=["answer"]),
+        )
+
+        (x_train, y_train), _ = load_test_data()
+
+        mock_responses = []
+        mock_responses.extend(mock_incorrect_completion_data())
+        mock_responses.extend(mock_completion_data())
+        mock_completion.side_effect = mock_responses
+
+        # Explicitly disable both validation paths.
+        history = await program.fit(
+            x=x_train,
+            y=y_train,
+            epochs=1,
+            batch_size=32,
+            validation_split=0.0,
+            validation_data=None,
+        )
+        self.assertIsNotNone(history)


### PR DESCRIPTION
## Summary

`fit()` crashes with `UnboundLocalError` / `TypeError` when called without validation data (e.g. `validation_split=0` and `validation_data=None`).

- `val_x` / `val_y` stay `None` but are passed unconditionally to `predict_on_batch`, `evaluate`, and `compute_metrics`.
- Also fixes a pre-existing typo on line 461: `val_y, val_y = None, None` -> `val_x, val_y = None, None`.
- Mirror fix in `Optimizer._iterate_one_batch` where the validation pass is skipped and training rewards are reused for candidate selection.

## Changes

**`synalinks/src/trainers/trainer.py`** (4 sites)
- Typo fix at the top of `fit()`.
- Guard minibatch sampling on `val_x is not None`.
- Skip `self.evaluate(...)` / emit empty `val_logs` when there is no validation data.
- In the non-trainable eval branch, fall back to training `x` / `y` so reward and metrics still get computed.

**`synalinks/src/optimizers/optimizer.py`** (`_iterate_one_batch`)
- When `val_x is None`, reuse training `y_pred` / `rewards` for candidate selection and metric computation instead of re-running `predict_on_batch(None)`.

## Test plan

- [x] New regression test `TestTrainer::test_fit_without_validation_data` — calls `fit(x, y, epochs=1, validation_split=0.0, validation_data=None)` and asserts `history` is returned.
- [x] Verified the new test fails on the pre-patched code with `UnboundLocalError: cannot access local variable 'val_x'` at `trainer.py:556`.
- [x] Full trainer + optimizer suites pass locally: `uv run pytest synalinks/src/trainers/ synalinks/src/optimizers/` (48 passed).