### PR TITLE
fix(rewards): warn and score 0.0 when judge program returns None

### DIFF
--- a/synalinks/src/rewards/reward_wrappers.py
+++ b/synalinks/src/rewards/reward_wrappers.py
@@ -2,6 +2,8 @@
 # Original authors: François Chollet et al. (Keras Team)
 # License Apache 2.0: (c) 2025 Yoan Sallami (Synalinks Team)
 
+import warnings
+
 from synalinks.src.api_export import synalinks_export
 from synalinks.src.rewards.reward import Reward
 from synalinks.src.saving import serialization_lib
@@ -129,6 +131,16 @@ class ProgramAsJudge(Reward):
 
     async def call(self, y_true, y_pred):
         result = await self.program([y_true, y_pred])
+        if result is None:
+            warnings.warn(
+                f"{self.__class__.__name__}: judge program returned None "
+                "(likely an LLM / provider failure). Scoring this sample as "
+                "0.0 and continuing. Check the underlying language model "
+                "and structured-output configuration.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return 0.0
         return float(result.get("reward", 0.0))
 
     def get_config(self):

--- a/synalinks/src/rewards/reward_wrappers_test.py
+++ b/synalinks/src/rewards/reward_wrappers_test.py
@@ -1,5 +1,6 @@
 # License Apache 2.0: (c) 2025 Yoan Sallami (Synalinks Team)
 
+import warnings
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
@@ -92,6 +93,27 @@ class ProgramAsJudgeTest(testing.TestCase):
 
         reward = await judge(y_true, y_pred)
         self.assertEqual(reward, 0.0)
+
+    async def test_call_program_returns_none(self):
+        """Judge must return 0.0 and warn (not crash) when the program fails."""
+        class Answer(DataModel):
+            answer: str
+
+        mock_program = AsyncMock()
+        mock_program.return_value = None
+
+        judge = ProgramAsJudge(program=mock_program)
+        y_true = Answer(answer="hello")
+        y_pred = Answer(answer="world")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            reward = await judge(y_true, y_pred)
+
+        self.assertEqual(reward, 0.0)
+        judge_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+        self.assertEqual(len(judge_warnings), 1)
+        self.assertIn("returned None", str(judge_warnings[0].message))
 
     def test_get_config(self):
         mock_program = MagicMock()


### PR DESCRIPTION
## Summary

`ProgramAsJudge.call` crashes on `AttributeError: 'NoneType' object has no attribute 'get'` when the underlying judge program returns `None` (malformed LLM output, provider timeout, structured-output mismatch…). That kills the entire training loop because of a single failed sample.

Instead, emit a `RuntimeWarning` — so the user sees there is a problem with the judge LLM and can investigate — and score the sample as `0.0` so training continues.

## Changes

- `synalinks/src/rewards/reward_wrappers.py` — `ProgramAsJudge.call` now warns + returns `0.0` on `None`.
- `synalinks/src/rewards/reward_wrappers_test.py` — new `test_call_program_returns_none` asserts both the `0.0` return and the `RuntimeWarning`.

## Test plan

- [x] New regression test passes on patched code.
- [x] Full rewards suite green: `uv run pytest synalinks/src/rewards/reward_wrappers_test.py` (10 passed).