### PR TITLE
chore(deps): pin litellm>=1.82

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "inquirer",
   "jinja2",
   "jsonschema",
-  "litellm",
+  "litellm>=1.82",
   "matplotlib",
   "mcp",
   "mixpanel",

--- a/uv.lock
+++ b/uv.lock
@@ -1509,7 +1509,7 @@ name = "gunicorn"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/f4/e78fa054248fab913e2eab0332c6c2cb07421fca1ce56d8fe43b6aef57a4/gunicorn-25.3.0.tar.gz", hash = "sha256:f74e1b2f9f76f6cd1ca01198968bd2dd65830edc24b6e8e4d78de8320e2fe889", size = 634883 }
 wheels = [
@@ -4528,7 +4528,7 @@ requires-dist = [
     { name = "inquirer" },
     { name = "jinja2" },
     { name = "jsonschema" },
-    { name = "litellm" },
+    { name = "litellm", specifier = ">=1.82" },
     { name = "matplotlib" },
     { name = "mcp" },
     { name = "mixpanel" },


### PR DESCRIPTION
## Summary

litellm 1.82 fixed event-loop safety for its `GLOBAL_LOGGING_WORKER`. Earlier versions leak tasks bound to a closed event loop and produce noisy "Task exception was never retrieved" / "bound to a different event loop" errors at the end of `asyncio.run(...)` calls — very visible when running Synalinks programs from short scripts or CLIs.

Downstream projects have been monkey-patching `litellm.module_level_aclient` to work around this; pinning `>=1.82` makes those workarounds unnecessary.

## Changes

- `pyproject.toml` — `"litellm"` → `"litellm>=1.82"`
- `uv.lock` — regenerated (`uv lock`). The unrelated `gunicorn` `packaging` marker update is what the current uv resolver produces for the existing lockfile; no new transitive changes.

## Test plan

- [x] `uv lock` succeeds.
- [x] No code change, no new test — environment constraint only.