### PR TITLE
fix(optimizers): fallback to seed_candidates in propose_new_candidates

### DIFF
--- a/synalinks/src/optimizers/evolutionary_optimizer.py
+++ b/synalinks/src/optimizers/evolutionary_optimizer.py
@@ -199,6 +199,16 @@ class EvolutionaryOptimizer(Optimizer):
                 best_candidates = trainable_variable.get("best_candidates")
                 selected_candidate = self.select_candidate(best_candidates)
 
+                # On the very first training step `best_candidates` is still
+                # empty (it is populated downstream by `maybe_add_candidate`).
+                # Fall back to a seed candidate so mutation/crossover has
+                # something to work with, mirroring the same fallback used in
+                # `on_batch_begin`.
+                if selected_candidate is None:
+                    seed_candidates = trainable_variable.get("seed_candidates")
+                    if seed_candidates:
+                        selected_candidate = random.choice(seed_candidates)
+
                 if strategy == "mutation":
                     new_candidate = await self.mutate_candidate(
                         step,

--- a/synalinks/src/optimizers/evolutionary_optimizer_test.py
+++ b/synalinks/src/optimizers/evolutionary_optimizer_test.py
@@ -199,6 +199,77 @@ class EvolutionaryOptimizerTest(testing.TestCase):
         optimizer = EvolutionaryOptimizer()
         self.assertEqual(optimizer.sampling_temperature, 0.3)
 
+    async def test_propose_new_candidates_falls_back_to_seed_when_best_empty(
+        self,
+    ):
+        """Regression test: on the very first training step `best_candidates`
+        is still empty (it is populated later by `maybe_add_candidate`).
+        `propose_new_candidates` used to pass the resulting `None` into
+        `mutate_candidate`, which crashed downstream (e.g. OMEGA's
+        `selected_candidate.items()` in `omega.py`). It must instead fall
+        back to a random seed candidate, mirroring `on_batch_begin`.
+        """
+        seen = {}
+
+        class _RecordingOptimizer(EvolutionaryOptimizer):
+            async def mutate_candidate(
+                self,
+                step,
+                trainable_variable,
+                selected_candidate,
+                x=None,
+                y=None,
+                y_pred=None,
+                training=False,
+            ):
+                seen["selected_candidate"] = selected_candidate
+                return None
+
+            async def merge_candidate(
+                self,
+                step,
+                trainable_variable,
+                current_candidate,
+                other_candidate,
+                x=None,
+                y=None,
+                y_pred=None,
+                training=False,
+            ):
+                return None
+
+        # merging_rate=0 keeps the strategy on "mutation" regardless of epoch.
+        optimizer = _RecordingOptimizer(selection="random", merging_rate=0.0)
+
+        seed_candidate = {"prompt": "seed_prompt"}
+        trainable_variable = JsonDataModel(
+            json={
+                "seed_candidates": [seed_candidate],
+                "best_candidates": [],
+                "nb_visit": 0,
+                "cumulative_reward": 0.0,
+                "prompt": "initial",
+            },
+            schema={
+                "type": "object",
+                "properties": {
+                    "seed_candidates": {"type": "array"},
+                    "best_candidates": {"type": "array"},
+                    "nb_visit": {"type": "integer"},
+                    "cumulative_reward": {"type": "number"},
+                    "prompt": {"type": "string"},
+                },
+            },
+            name="trainable_var",
+        )
+
+        await optimizer.propose_new_candidates(
+            step=0,
+            trainable_variables=[trainable_variable],
+        )
+
+        self.assertEqual(seen.get("selected_candidate"), seed_candidate)
+
     async def test_select_variable_name_to_update_does_not_raise(self):
         """Regression test: `select_variable_name_to_update` on an
         EvolutionaryOptimizer used to raise


### PR DESCRIPTION
## Summary

`EvolutionaryOptimizer.propose_new_candidates` calls `select_candidate` on `best_candidates`, which on the very first training step is still empty (it is populated later by `maybe_add_candidate`). The resulting `None` is then passed as `selected_candidate` into `mutate_candidate` / `merge_candidate`, crashing concrete subclasses such as `OMEGA` on `selected_candidate.items()` in `omega.py`.

The companion method `on_batch_begin` already handles this situation by falling back to a random seed candidate. This PR applies the exact same fallback in `propose_new_candidates`, keeping behaviour consistent across the class and letting OMEGA (and any future `EvolutionaryOptimizer` subclass) run `fit()` without pre-populating `best_candidates`.

## Reproduction

```python
program.compile(
    reward=synalinks.rewards.ExactMatch(in_mask=["answer"]),
    optimizer=synalinks.optimizers.OMEGA(
        language_model=lm,
        embedding_model=em,
    ),
)

await program.fit(x=x_train, y=y_train, epochs=1, batch_size=1, validation_split=0.2)
```

Before the fix this crashes at step 0 with:

```
AttributeError: 'NoneType' object has no attribute 'items'
  at omega.py:457 in mutate_candidate
```

## Changes

- `synalinks/src/optimizers/evolutionary_optimizer.py`: in `propose_new_candidates`, when `select_candidate(best_candidates)` returns `None`, fall back to a random seed candidate (mirroring `on_batch_begin`).
- `synalinks/src/optimizers/evolutionary_optimizer_test.py`: add `test_propose_new_candidates_falls_back_to_seed_when_best_empty`. The test subclasses `EvolutionaryOptimizer` to record what `mutate_candidate` receives, and verifies it is the seed candidate (not `None`). The test fails on `main` and passes with this fix.

## Test plan

- [x] New regression test passes with the fix applied
- [x] New regression test fails without the fix (verified by stashing the fix and re-running)
- [x] Full `evolutionary_optimizer_test.py` suite passes (15/15)