### PR TITLE
fix(backend): preserve \$ref and handle missing type in factorize_schema

### DIFF
--- a/synalinks/src/backend/common/json_schema_utils.py
+++ b/synalinks/src/backend/common/json_schema_utils.py
@@ -233,7 +233,12 @@ def factorize_schema(schema):
                     else:
                         array_prop["items"] = prop_value["items"]
                 else:
-                    array_prop["items"] = {"type": prop_value["type"]}
+                    if "$ref" in prop_value:
+                        array_prop["items"] = {"$ref": prop_value["$ref"]}
+                    elif "type" in prop_value:
+                        array_prop["items"] = {"type": prop_value["type"]}
+                    else:
+                        array_prop["items"] = {"type": "string"}
 
                 result_schema["properties"][plural_key] = array_prop
                 if plural_key not in result_schema["required"]:


### PR DESCRIPTION
When factorize_schema merges similarly-named scalar properties into a single array property, it blindly indexed prop_value["type"] on the non-array branch. For nested-DataModel properties, Pydantic emits {"\$ref": "..."} without a "type" key, raising KeyError. Preserve the \$ref when present, keep the type branch for typed scalars, and fall back to string for malformed entries.