### PR TITLE
feat: add MultiDecision + dynamic_enum_array

### DIFF
--- a/synalinks/__init__.py
+++ b/synalinks/__init__.py
@@ -36,6 +36,7 @@ from synalinks.api import LMAsJudge
 from synalinks.api import Metric
 from synalinks.api import Module
 from synalinks.api import MontySandbox
+from synalinks.api import MultiDecision
 from synalinks.api import MultiServerMCPClient
 from synalinks.api import Not
 from synalinks.api import Operation

--- a/synalinks/api/__init__.py
+++ b/synalinks/api/__init__.py
@@ -103,6 +103,7 @@ from synalinks.src.modules.core.generator import (
 )
 from synalinks.src.modules.core.identity import Identity as Identity
 from synalinks.src.modules.core.input_module import Input as Input
+from synalinks.src.modules.core.multi_decision import MultiDecision as MultiDecision
 from synalinks.src.modules.core.not_module import Not as Not
 from synalinks.src.modules.core.tool import Tool as Tool
 from synalinks.src.modules.embedding_models.embedding_model import (

--- a/synalinks/api/modules/__init__.py
+++ b/synalinks/api/modules/__init__.py
@@ -22,6 +22,7 @@ from synalinks.src.modules.core.generator import Generator as Generator
 from synalinks.src.modules.core.identity import Identity as Identity
 from synalinks.src.modules.core.input_module import Input as Input
 from synalinks.src.modules.core.input_module import InputModule as InputModule
+from synalinks.src.modules.core.multi_decision import MultiDecision as MultiDecision
 from synalinks.src.modules.core.not_module import Not as Not
 from synalinks.src.modules.core.tool import Tool as Tool
 from synalinks.src.modules.knowledge.embed_knowledge import (

--- a/synalinks/src/backend/__init__.py
+++ b/synalinks/src/backend/__init__.py
@@ -11,6 +11,7 @@ if backend() == "pydantic":
 from synalinks.src.api_export import synalinks_export
 from synalinks.src.backend.common import name_scope
 from synalinks.src.backend.common.dynamic_json_schema_utils import dynamic_enum
+from synalinks.src.backend.common.dynamic_json_schema_utils import dynamic_enum_array
 from synalinks.src.backend.common.dynamic_json_schema_utils import dynamic_tool_calls
 from synalinks.src.backend.common.dynamic_json_schema_utils import dynamic_tool_choice
 from synalinks.src.backend.common.json_schema_utils import concatenate_schema

--- a/synalinks/src/backend/common/dynamic_json_schema_utils.py
+++ b/synalinks/src/backend/common/dynamic_json_schema_utils.py
@@ -44,6 +44,95 @@ def dynamic_enum(schema, prop_to_update, labels, description=None, inline=True):
     return schema
 
 
+def dynamic_enum_array(schema, prop_to_update, labels, description=None, inline=True):
+    """Update a schema with a dynamic Enum string applied to array items.
+
+    Mirrors :func:`dynamic_enum` but targets list-valued properties whose
+    items should be constrained to a string enum (i.e. ``list[str]`` /
+    ``list[Literal[...]]`` in pydantic).
+
+    The property may live at the top level under ``properties``, or nested
+    inside any ``$defs`` entry (typical for pydantic schemas that factor
+    nested models out to ``$defs``). The first match is patched.
+
+    Args:
+        schema (dict): The schema to update (not mutated — deep-copied).
+        prop_to_update (str): The array property to update.
+        labels (list): The list of labels (strings) allowed as items.
+        description (str, optional): An optional description for the
+            property.
+        inline (bool): When True the enum is placed directly in the
+            array items (no ``$defs`` / ``$ref`` indirection). Defaults
+            to True for parity with :func:`dynamic_enum`.
+
+    Returns:
+        dict: The updated schema with the items-enum applied to the
+            specified property.
+
+    Raises:
+        ValueError: If no matching property is found anywhere in the
+            schema.
+    """
+    schema = copy.deepcopy(schema)
+    labels_list = list(labels)
+
+    if inline:
+        items_value = {"type": "string", "enum": labels_list}
+    else:
+        if schema.get("$defs"):
+            schema = {"$defs": schema.pop("$defs"), **schema}
+        else:
+            schema = {"$defs": {}, **schema}
+        title = prop_to_update.title().replace("_", "")
+
+        enum_definition = {
+            "enum": labels_list,
+            "title": title,
+            "type": "string",
+        }
+        if description:
+            enum_definition["description"] = description
+        schema["$defs"].update({title: enum_definition})
+        items_value = {"$ref": f"#/$defs/{title}"}
+
+    def _patch_in_properties(props):
+        if not isinstance(props, dict) or prop_to_update not in props:
+            return False
+        prop = props[prop_to_update]
+        if not isinstance(prop, dict):
+            return False
+        prop["type"] = "array"
+        prop["items"] = items_value
+        prop.pop("enum", None)
+        if description:
+            prop["description"] = description
+        return True
+
+    seen_keys = []
+    defs = schema.get("$defs") or {}
+    for def_name, def_body in defs.items():
+        if not isinstance(def_body, dict):
+            continue
+        if not inline and def_name == prop_to_update.title().replace("_", ""):
+            continue
+        def_props = def_body.get("properties")
+        if isinstance(def_props, dict):
+            seen_keys.extend(f"$defs.{def_name}.{k}" for k in def_props)
+            if _patch_in_properties(def_props):
+                return schema
+
+    top_props = schema.get("properties")
+    if isinstance(top_props, dict):
+        seen_keys.extend(top_props.keys())
+        if _patch_in_properties(top_props):
+            return schema
+
+    raise ValueError(
+        f"dynamic_enum_array: property {prop_to_update!r} not found. "
+        f"Seen keys: {seen_keys!r}"
+    )
+
+
 def dynamic_tool_calls(tools, inline=True):
     """
     Generates a dynamic schema for tool calls based on a list of tools.

--- a/synalinks/src/backend/common/dynamic_json_schema_utils_test.py
+++ b/synalinks/src/backend/common/dynamic_json_schema_utils_test.py
@@ -1,11 +1,14 @@
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
 from enum import Enum
+from typing import List
 
 from synalinks.src import testing
 from synalinks.src.backend import DataModel
+from synalinks.src.backend import Field
 from synalinks.src.backend import is_schema_equal
 from synalinks.src.backend.common.dynamic_json_schema_utils import dynamic_enum
+from synalinks.src.backend.common.dynamic_json_schema_utils import dynamic_enum_array
 from synalinks.src.backend.common.dynamic_json_schema_utils import dynamic_tool_calls
 from synalinks.src.backend.common.dynamic_json_schema_utils import dynamic_tool_choice
 from synalinks.src.utils.tool_utils import Tool
@@ -94,6 +97,108 @@ class DynamicEnumTest(testing.TestCase):
         # No indirection through $defs.
         self.assertNotIn("$ref", choice)
         self.assertNotIn("Choice", schema.get("$defs", {}))
+
+
+class DynamicEnumArrayTest(testing.TestCase):
+    """Cover the `list[Literal[...]]` patching used by `MultiDecision`."""
+
+    def test_inline_basic(self):
+        class MultiDecisionAnswer(DataModel):
+            thinking: str
+            choices: List[str] = Field(default_factory=list)
+
+        labels = ["a", "b", "c"]
+        schema = dynamic_enum_array(
+            MultiDecisionAnswer.get_schema(),
+            "choices",
+            labels,
+            inline=True,
+        )
+        choices = schema["properties"]["choices"]
+        self.assertEqual(choices["type"], "array")
+        self.assertEqual(choices["items"], {"type": "string", "enum": labels})
+        self.assertNotIn("Choices", schema.get("$defs", {}))
+
+    def test_ref_mode(self):
+        class MultiDecisionAnswer(DataModel):
+            thinking: str
+            choices: List[str] = Field(default_factory=list)
+
+        labels = ["x", "y"]
+        schema = dynamic_enum_array(
+            MultiDecisionAnswer.get_schema(),
+            "choices",
+            labels,
+            inline=False,
+        )
+        choices = schema["properties"]["choices"]
+        self.assertEqual(choices["type"], "array")
+        self.assertEqual(choices["items"], {"$ref": "#/$defs/Choices"})
+        self.assertIn("Choices", schema["$defs"])
+        self.assertEqual(schema["$defs"]["Choices"]["enum"], labels)
+
+    def test_with_description(self):
+        class MultiDecisionAnswer(DataModel):
+            thinking: str
+            choices: List[str] = Field(default_factory=list)
+
+        schema = dynamic_enum_array(
+            MultiDecisionAnswer.get_schema(),
+            "choices",
+            ["a", "b"],
+            description="Pick one or more",
+        )
+        self.assertEqual(
+            schema["properties"]["choices"]["description"], "Pick one or more"
+        )
+
+    def test_empty_labels(self):
+        class MultiDecisionAnswer(DataModel):
+            thinking: str
+            choices: List[str] = Field(default_factory=list)
+
+        schema = dynamic_enum_array(
+            MultiDecisionAnswer.get_schema(),
+            "choices",
+            [],
+        )
+        self.assertEqual(schema["properties"]["choices"]["items"]["enum"], [])
+
+    def test_property_in_defs(self):
+        """Pydantic puts nested models in `$defs` — the helper must
+        traverse them when matching the property name."""
+
+        class Inner(DataModel):
+            choices: List[str] = Field(default_factory=list)
+
+        class Outer(DataModel):
+            inner: Inner = Field(default_factory=Inner)
+
+        schema = dynamic_enum_array(
+            Outer.get_schema(),
+            "choices",
+            ["a", "b"],
+            inline=True,
+        )
+        # Property is inside $defs.Inner.properties.
+        inner_def = schema["$defs"]["Inner"]
+        self.assertEqual(
+            inner_def["properties"]["choices"]["items"],
+            {"type": "string", "enum": ["a", "b"]},
+        )
+
+    def test_not_found_raises(self):
+        class MultiDecisionAnswer(DataModel):
+            thinking: str
+            choices: List[str] = Field(default_factory=list)
+
+        with self.assertRaises(ValueError) as ctx:
+            dynamic_enum_array(
+                MultiDecisionAnswer.get_schema(),
+                "missing_field",
+                ["a", "b"],
+            )
+        self.assertIn("missing_field", str(ctx.exception))
 
 
 class DynamicToolCallsSchemaTest(testing.TestCase):

--- a/synalinks/src/modules/core/branch.py
+++ b/synalinks/src/modules/core/branch.py
@@ -12,13 +12,26 @@ from synalinks.src.saving import serialization_lib
 
 @synalinks_export(["synalinks.modules.Branch", "synalinks.Branch"])
 class Branch(Module):
-    """Use a `LanguageModel` to select which module to call based on an arbitrary
-        input, a question and a list of labels.
+    """Use a `LanguageModel` to select which module(s) to call based on an
+        arbitrary input, a question and a list of labels.
 
-    The selected branch output the data model computed using
-    the inputs and module's branch, while the others output `None`.
+    The selected branch(es) output the data model computed using the inputs
+    and module's branch, while the others output `None`. The output is
+    always a tuple of length `len(branches)` so each label has a fixed
+    positional slot regardless of which one was selected.
 
-    Example:
+    The behaviour of the selector depends on `decision_type`:
+
+    - `decision_type=Decision` (default) — exactly **one** branch is
+      selected per call. All other slots are `None`.
+    - `decision_type=MultiDecision` — **one or more** branches are
+      selected per call. Non-selected slots remain `None`. Use this for
+      multi-label routing where several branches may need to fire at
+      once (e.g., an article that spans both `science` and `finance`,
+      or a query that should be answered by both a retrieval and a
+      tool-using sub-program).
+
+    Single-label example (one branch active per call):
 
     ```python
     import synalinks
@@ -69,6 +82,65 @@ class Branch(Module):
         asyncio.run(main())
     ```
 
+    Multi-label example (zero, one, or several branches active per call):
+
+    ```python
+    import synalinks
+    import asyncio
+
+    async def main():
+        class Article(synalinks.DataModel):
+            text: str
+
+        class ScienceSummary(synalinks.DataModel):
+            thinking: str
+            science_summary: str
+
+        class FinanceSummary(synalinks.DataModel):
+            thinking: str
+            finance_summary: str
+
+        class SportsSummary(synalinks.DataModel):
+            thinking: str
+            sports_summary: str
+
+        language_model = synalinks.LanguageModel(model="ollama/mistral")
+
+        x0 = synalinks.Input(data_model=Article)
+        # Each label has a fixed slot in the output tuple. With
+        # MultiDecision, several may be populated at once; the rest
+        # are None.
+        (sci, fin, spo) = await synalinks.Branch(
+            question="Which topics does this article cover?",
+            labels=["science", "finance", "sports"],
+            branches=[
+                synalinks.Generator(
+                    data_model=ScienceSummary,
+                    language_model=language_model,
+                ),
+                synalinks.Generator(
+                    data_model=FinanceSummary,
+                    language_model=language_model,
+                ),
+                synalinks.Generator(
+                    data_model=SportsSummary,
+                    language_model=language_model,
+                ),
+            ],
+            decision_type=synalinks.MultiDecision,
+            language_model=language_model,
+        )(x0)
+
+    if __name__ == "__main__":
+        asyncio.run(main())
+    ```
+
+    For a biotech-startup article the result might be
+    `(<ScienceSummary>, <FinanceSummary>, None)` — `science` and
+    `finance` are both active, `sports` stays `None`. The non-active
+    slots can be combined downstream with `|` (logical OR) the same
+    way as in the single-label example.
+
     Args:
         question (str): The question to ask.
         labels (list): The list of labels to choose from (strings).
@@ -93,7 +165,10 @@ class Branch(Module):
             schema in the decision prompt (Default to False) (see `Decision`).
         use_outputs_schema (bool): Optional. Whether or not use the outputs
             schema in the decision prompt (Default to False) (see `Decision`).
-        decision_type (bool): Optional. The type of decision module to use.
+        decision_type (type): Optional. The decision module class. Defaults to
+            `Decision` (single-label, exactly one branch active). Pass
+            `MultiDecision` to enable multi-label routing where several
+            branches may be active simultaneously.
         name (str): Optional. The name of the module.
         description (str): Optional. The description of the module.
         trainable (bool): Whether the module's variables should be trainable.

--- a/synalinks/src/modules/core/multi_decision.py
+++ b/synalinks/src/modules/core/multi_decision.py
@@ -1,0 +1,217 @@
+# License Apache 2.0: (c) 2025 Yoan Sallami (Synalinks Team)
+
+
+from typing import List
+
+from synalinks.src import ops
+from synalinks.src.api_export import synalinks_export
+from synalinks.src.backend import DataModel
+from synalinks.src.backend import Field
+from synalinks.src.backend import dynamic_enum_array
+from synalinks.src.modules.core.generator import Generator
+from synalinks.src.modules.language_models import get as _get_lm
+from synalinks.src.modules.module import Module
+from synalinks.src.saving import serialization_lib
+
+
+class Question(DataModel):
+    question: str = Field(description="The question to ask yourself.")
+
+
+class MultiDecisionAnswer(DataModel):
+    thinking: str = Field(
+        description="Your step by step thinking to choose the correct labels."
+    )
+    choices: List[str] = Field(description="The chosen labels (one or more).")
+
+
+def default_multi_decision_instructions(labels):
+    """The multi-decision default instructions"""
+    return f"""
+You will be given a question, your task is to answer step-by-step to choose
+one or more of the following labels: {labels}
+""".strip()
+
+
+@synalinks_export(["synalinks.modules.MultiDecision", "synalinks.MultiDecision"])
+class MultiDecision(Module):
+    """Perform a multi-label selection on the given input.
+
+    This module dynamically creates an array-of-enum schema based on
+    the given labels and uses it to generate a structured answer.
+
+    This ensures that the LM answer **always** contains only values
+    from the provided labels — no hallucinated entries.
+
+    Mirrors :class:`Decision` but allows **multiple** choices instead
+    of exactly one.
+
+    Example:
+
+    ```python
+    import synalinks
+    import asyncio
+
+    async def main():
+
+        language_model = synalinks.LanguageModel(
+            model="ollama/mistral",
+        )
+
+        x0 = synalinks.Input(data_model=synalinks.ChatMessages)
+        x1 = await synalinks.MultiDecision(
+            question="Which topics does this article cover?",
+            labels=["science", "politics", "sports", "technology"],
+            language_model=language_model,
+        )(x0)
+
+        program = synalinks.Program(
+            inputs=x0,
+            outputs=x1,
+            name="article_topic_classifier",
+            description="Multi-label topic classifier.",
+        )
+
+    if __name__ == "__main__":
+        asyncio.run(main())
+    ```
+
+    The output contains ``thinking`` (chain-of-thought) and ``choices``
+    (a list constrained to the provided labels).
+
+    Args:
+        question (str): The question to ask.
+        labels (list): The list of labels to choose from (strings).
+        language_model (LanguageModel): The language model to use.
+        inline (bool): When True the enum is placed directly in the
+            array items (no ``$defs`` / ``$ref`` indirection).
+            Defaults to True for simpler schemas.
+        prompt_template (str): The default jinja2 prompt template
+            to use (see ``Generator``).
+        examples (list): The default examples to use in the prompt
+            (see ``Generator``).
+        instructions (list): The default instructions to use
+            (see ``Generator``).
+        seed_instructions (list): Optional. A list of instructions to
+            use as seed for the optimization. If not provided, use the
+            default instructions as seed.
+        temperature (float): Optional. The temperature for the LM call.
+        reasoning_effort (string): Optional. The reasoning effort for the
+            LM call between
+            ['minimal', 'low', 'medium', 'high', 'disable', 'none', None].
+            Default to None (no reasoning).
+        use_inputs_schema (bool): Optional. Whether or not use the inputs
+            schema in the prompt (Default to False) (see ``Generator``).
+        use_outputs_schema (bool): Optional. Whether or not use the outputs
+            schema in the prompt (Default to False) (see ``Generator``).
+        name (str): Optional. The name of the module.
+        description (str): Optional. The description of the module.
+        trainable (bool): Whether the module's variables should be
+            trainable.
+    """
+
+    def __init__(
+        self,
+        *,
+        question=None,
+        labels=None,
+        language_model=None,
+        inline=True,
+        prompt_template=None,
+        examples=None,
+        instructions=None,
+        seed_instructions=None,
+        temperature=0.0,
+        reasoning_effort=None,
+        use_inputs_schema=False,
+        use_outputs_schema=False,
+        name=None,
+        description=None,
+        trainable=True,
+    ):
+        super().__init__(
+            name=name,
+            description=description,
+            trainable=trainable,
+        )
+        if not question:
+            raise ValueError("The `question` argument must be provided.")
+        if not labels:
+            raise ValueError("The `labels` argument must be provided.")
+        if not isinstance(labels, list):
+            raise ValueError("The `labels` parameter must be a list of string.")
+        schema = dynamic_enum_array(
+            MultiDecisionAnswer.get_schema(),
+            "choices",
+            labels,
+            inline=inline,
+        )
+        self.schema = schema
+        self.question = question
+        self.labels = labels
+        self.inline = inline
+        self.language_model = _get_lm(language_model)
+        self.prompt_template = prompt_template
+        self.examples = examples
+        if not instructions:
+            instructions = default_multi_decision_instructions(self.labels)
+        self.instructions = instructions
+        self.seed_instructions = seed_instructions
+        self.temperature = temperature
+        self.reasoning_effort = reasoning_effort
+        self.use_inputs_schema = use_inputs_schema
+        self.use_outputs_schema = use_outputs_schema
+        self.decision = Generator(
+            schema=self.schema,
+            language_model=self.language_model,
+            prompt_template=self.prompt_template,
+            examples=self.examples,
+            instructions=self.instructions,
+            temperature=self.temperature,
+            reasoning_effort=self.reasoning_effort,
+            use_inputs_schema=self.use_inputs_schema,
+            use_outputs_schema=self.use_outputs_schema,
+            name="generator_" + self.name,
+        )
+
+    async def call(self, inputs, training=False):
+        if not inputs:
+            return None
+        inputs = await ops.concat(
+            inputs,
+            Question(question=self.question),
+            name="inputs_with_question_" + self.name,
+        )
+        result = await self.decision(inputs, training=training)
+        return result
+
+    def get_config(self):
+        config = {
+            "question": self.question,
+            "labels": self.labels,
+            "inline": self.inline,
+            "prompt_template": self.prompt_template,
+            "examples": self.examples,
+            "instructions": self.instructions,
+            "seed_instructions": self.seed_instructions,
+            "temperature": self.temperature,
+            "reasoning_effort": self.reasoning_effort,
+            "use_inputs_schema": self.use_inputs_schema,
+            "use_outputs_schema": self.use_outputs_schema,
+            "name": self.name,
+            "description": self.description,
+            "trainable": self.trainable,
+        }
+        language_model_config = {
+            "language_model": serialization_lib.serialize_synalinks_object(
+                self.language_model
+            )
+        }
+        return {**config, **language_model_config}
+
+    @classmethod
+    def from_config(cls, config):
+        language_model = serialization_lib.deserialize_synalinks_object(
+            config.pop("language_model")
+        )
+        return cls(language_model=language_model, **config)

--- a/synalinks/src/modules/core/multi_decision_test.py
+++ b/synalinks/src/modules/core/multi_decision_test.py
@@ -1,0 +1,146 @@
+# License Apache 2.0: (c) 2025 Yoan Sallami (Synalinks Team)
+
+import json
+from unittest.mock import patch
+
+from synalinks.src import testing
+from synalinks.src.backend import DataModel
+from synalinks.src.backend import dynamic_enum_array
+from synalinks.src.modules.language_models import LanguageModel
+from synalinks.src.modules import Input
+from synalinks.src.modules.core.multi_decision import MultiDecision
+from synalinks.src.modules.core.multi_decision import MultiDecisionAnswer
+from synalinks.src.programs import Program
+
+
+class MultiDecisionTest(testing.TestCase):
+    @patch("litellm.acompletion")
+    async def test_basic_multi_decision(self, mock_completion):
+        class Query(DataModel):
+            query: str
+
+        language_model = LanguageModel(
+            model="ollama/mistral",
+        )
+
+        expected_string = json.dumps(
+            {
+                "thinking": "The article discusses CRISPR gene editing "
+                "applied to cancer, which covers science and health.",
+                "choices": ["science", "health"],
+            }
+        )
+
+        mock_completion.return_value = {
+            "choices": [{"message": {"content": expected_string}}]
+        }
+
+        x0 = Input(data_model=Query)
+        x1 = await MultiDecision(
+            question="Which topics does this article cover?",
+            labels=["science", "politics", "sports", "health"],
+            language_model=language_model,
+        )(x0)
+
+        program = Program(
+            inputs=x0,
+            outputs=x1,
+        )
+
+        result = await program(
+            Query(
+                query="Researchers have developed a new CRISPR technique "
+                "that could revolutionize cancer treatment."
+            )
+        )
+
+        self.assertEqual(result.get_json(), json.loads(expected_string))
+
+    @patch("litellm.acompletion")
+    async def test_multi_decision_single_choice(self, mock_completion):
+        """MultiDecision should work when only one label is selected."""
+
+        class Query(DataModel):
+            query: str
+
+        language_model = LanguageModel(
+            model="ollama/mistral",
+        )
+
+        expected_string = json.dumps(
+            {
+                "thinking": "This is clearly about sports.",
+                "choices": ["sports"],
+            }
+        )
+
+        mock_completion.return_value = {
+            "choices": [{"message": {"content": expected_string}}]
+        }
+
+        x0 = Input(data_model=Query)
+        x1 = await MultiDecision(
+            question="Which topics?",
+            labels=["science", "sports"],
+            language_model=language_model,
+        )(x0)
+
+        program = Program(inputs=x0, outputs=x1)
+
+        result = await program(Query(query="Olympic athletes set new records."))
+
+        self.assertEqual(result.get("choices"), ["sports"])
+
+    def test_schema_uses_inline_by_default(self):
+        """Default inline=True should produce items with direct enum."""
+        labels = ["a", "b", "c"]
+        schema = dynamic_enum_array(
+            MultiDecisionAnswer.get_schema(),
+            "choices",
+            labels,
+            inline=True,
+        )
+        items = schema["properties"]["choices"]["items"]
+        self.assertEqual(items, {"type": "string", "enum": labels})
+        self.assertNotIn("Choices", schema.get("$defs", {}))
+
+    def test_schema_ref_mode(self):
+        """inline=False should produce $ref items."""
+        labels = ["x", "y"]
+        schema = dynamic_enum_array(
+            MultiDecisionAnswer.get_schema(),
+            "choices",
+            labels,
+            inline=False,
+        )
+        items = schema["properties"]["choices"]["items"]
+        self.assertEqual(items, {"$ref": "#/$defs/Choices"})
+        self.assertIn("Choices", schema["$defs"])
+
+    def test_missing_question_raises(self):
+        with self.assertRaises(ValueError):
+            MultiDecision(
+                labels=["a", "b"],
+                language_model=LanguageModel(model="ollama/mistral"),
+            )
+
+    def test_missing_labels_raises(self):
+        with self.assertRaises(ValueError):
+            MultiDecision(
+                question="Pick topics",
+                language_model=LanguageModel(model="ollama/mistral"),
+            )
+
+    def test_serialization_round_trip(self):
+        """get_config / from_config must survive a round trip."""
+        lm = LanguageModel(model="ollama/mistral")
+        md = MultiDecision(
+            question="Pick topics",
+            labels=["a", "b", "c"],
+            language_model=lm,
+            inline=True,
+        )
+        config = md.get_config()
+        self.assertEqual(config["question"], "Pick topics")
+        self.assertEqual(config["labels"], ["a", "b", "c"])
+        self.assertTrue(config["inline"])


### PR DESCRIPTION
## Summary

Adds `MultiDecision` — a multi-label counterpart to `Decision` — and the
supporting `dynamic_enum_array` schema helper, plus a docstring rewrite
on `Branch` to spell out the multi-label contract.

Before this change there was no built-in way to constrain a `Generator`
output to a list of values drawn from a fixed label set; users had to
drop to `Decision` (single choice) and loop, or fall back to prompt-only
guidance (no structural guarantee).

## What this gives users

```python
x1 = await synalinks.MultiDecision(
    question="Which topics does this article cover?",
    labels=["science", "politics", "sports", "technology", "health"],
    language_model=lm,
)(x0)
# → {"thinking": "...", "choices": ["science", "health"]}
```

The decoder is constrained via JSON-schema `enum` items; off-label
strings are unreachable, matching the guarantee `Decision` already
provides for single-label selection.

`Branch` already supports both decision types via the `choice`/`choices`
lookup and an `isinstance(choice, (list, set))` selection path. With
`decision_type=MultiDecision`, several branches may fire at once while
the rest stay `None` — the output is always a `tuple` of length
`len(branches)`. The `Branch` docstring is updated to spell this
contract out and includes a multi-label example.

## Changes (3 commits)

1. **`feat(backend)`** — `dynamic_enum_array` helper
   - Mirrors `dynamic_enum` for list-valued properties whose items
     should be a string enum (`list[str]` / `list[Literal[...]]`).
   - Traverses `$defs` so nested pydantic models are matched; raises
     `ValueError` with the seen keys when the property is not found.
   - Default `inline=True` for parity with `dynamic_enum`.
   - Tests: 6 cases — both modes, `$defs` nesting, descriptions,
     empty labels, the not-found path.
   - Exported via `synalinks.src.backend.dynamic_enum_array`.

2. **`feat(modules)`** — `MultiDecision`
   - New module, mirrors `Decision`'s public API. `@synalinks_export`
     registers `synalinks.MultiDecision` and
     `synalinks.modules.MultiDecision`.
   - Tests: 7 cases (basic, single-choice, inline vs. ref schemas,
     missing-arg raises, config round-trip).
   - Public exports regenerated via `shell/api_gen.sh`.

3. **`docs(branch)`** — multi-branch setup
   - Docstring updated to state up-front that the output is always a
     tuple of length `len(branches)` with `None` for non-selected slots,
     regardless of `decision_type`.
   - Spells out the contract for both `Decision` (exactly one slot
     active) and `MultiDecision` (one or more slots active).
   - Adds a multi-label code example mirroring the existing single-label
     one.
   - **No behaviour change** — `branch.py` already supports both
     decision types; this commit documents the contract.

The earlier `inline`-on-`Decision` and `inline`-on-`dynamic_enum`
changes from previous revisions of this PR are dropped — they're
already in the latest release.

## Test plan

- [x] `uv run pytest synalinks/src/modules/core/multi_decision_test.py -v` — 7/7 pass
- [x] `uv run pytest synalinks/src/modules/core/branch_test.py -v` — 1/1 pass
- [x] `uv run pytest synalinks/src/backend/common/dynamic_json_schema_utils_test.py -v` — 12/12 pass (5 upstream + 6 new + 1 tool-choice)
- [x] `uvx ruff check` — clean on all PR-changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
