### PR TITLE
feat(language_model): add strict_mode option for structured output

### DIFF
--- a/synalinks/src/language_models/language_model.py
+++ b/synalinks/src/language_models/language_model.py
@@ -178,6 +178,10 @@ class LanguageModel(SynalinksSaveable):
         fallback (LanguageModel): Optional. The language model to fallback
             if anything is wrong.
         caching (bool): Optional. Enable caching of LM calls (Default to False).
+        strict_mode (bool): Optional. Whether to include the `strict` field
+            in the `response_format` of structured output calls. Some OpenAI-
+            compatible servers (e.g. TensorRT-LLM) reject unknown fields and
+            fail when `strict` is present. Default to True.
     """
 
     def __init__(
@@ -188,6 +192,7 @@ class LanguageModel(SynalinksSaveable):
         retry=5,
         fallback=None,
         caching=False,
+        strict_mode=True,
     ):
         if model is None:
             raise ValueError("You need to set the `model` argument for any LanguageModel")
@@ -211,6 +216,7 @@ class LanguageModel(SynalinksSaveable):
         self.timeout = timeout
         self.retry = retry
         self.caching = caching
+        self.strict_mode = strict_mode
         self.cumulated_cost = 0.0
         self.last_call_cost = 0.0
 
@@ -278,15 +284,13 @@ class LanguageModel(SynalinksSaveable):
                 )
             elif self.model.startswith("ollama") or self.model.startswith("mistral"):
                 # Use constrained structured output for ollama/mistral
-                kwargs.update(
-                    {
-                        "response_format": {
-                            "type": "json_schema",
-                            "json_schema": {"schema": schema},
-                            "strict": True,
-                        },
-                    }
-                )
+                response_format = {
+                    "type": "json_schema",
+                    "json_schema": {"schema": schema},
+                }
+                if self.strict_mode:
+                    response_format["strict"] = True
+                kwargs.update({"response_format": response_format})
             elif self.model.startswith("openai") or self.model.startswith("azure"):
                 # Use constrained structured output for openai/azure
                 # OpenAI/Azure require the field  "additionalProperties"
@@ -295,55 +299,47 @@ class LanguageModel(SynalinksSaveable):
                     for prop_key, prop_value in schema["properties"].items():
                         if "$ref" in prop_value and "description" in prop_value:
                             del prop_value["description"]
+                json_schema = {
+                    "name": "structured_output",
+                    "schema": schema,
+                }
+                if self.strict_mode:
+                    json_schema["strict"] = True
                 kwargs.update(
                     {
                         "response_format": {
                             "type": "json_schema",
-                            "json_schema": {
-                                "name": "structured_output",
-                                "strict": True,
-                                "schema": schema,
-                            },
+                            "json_schema": json_schema,
                         }
                     }
                 )
             elif self.model.startswith("gemini"):
-                kwargs.update(
-                    {
-                        "response_format": {
-                            "type": "json_schema",
-                            "json_schema": {
-                                "schema": schema,
-                            },
-                            "strict": True,
-                        }
-                    }
-                )
+                response_format = {
+                    "type": "json_schema",
+                    "json_schema": {"schema": schema},
+                }
+                if self.strict_mode:
+                    response_format["strict"] = True
+                kwargs.update({"response_format": response_format})
             elif self.model.startswith("xai"):
-                kwargs.update(
-                    {
-                        "response_format": {
-                            "type": "json_schema",
-                            "json_schema": {
-                                "schema": schema,
-                            },
-                            "strict": True,
-                        }
-                    }
-                )
+                response_format = {
+                    "type": "json_schema",
+                    "json_schema": {"schema": schema},
+                }
+                if self.strict_mode:
+                    response_format["strict"] = True
+                kwargs.update({"response_format": response_format})
             elif self.model.startswith("hosted_vllm"):
-                kwargs.update(
-                    {
-                        "response_format": {
-                            "type": "json_schema",
-                            "json_schema": {
-                                "name": "structured_output",
-                                "schema": schema,
-                            },
-                            "strict": True,
-                        }
-                    }
-                )
+                response_format = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "structured_output",
+                        "schema": schema,
+                    },
+                }
+                if self.strict_mode:
+                    response_format["strict"] = True
+                kwargs.update({"response_format": response_format})
             else:
                 provider = self.model.split("/")[0]
                 raise ValueError(
@@ -462,6 +458,7 @@ class LanguageModel(SynalinksSaveable):
             "timeout": self.timeout,
             "retry": self.retry,
             "caching": self.caching,
+            "strict_mode": self.strict_mode,
         }
         if self.fallback:
             fallback_config = {

--- a/synalinks/src/language_models/language_model_test.py
+++ b/synalinks/src/language_models/language_model_test.py
@@ -158,3 +158,92 @@ class LanguageModelTest(testing.TestCase):
         response_format = mock_completion.call_args.kwargs["response_format"]
         self.assertEqual(response_format["type"], "json_schema")
         self.assertEqual(response_format["json_schema"]["name"], "structured_output")
+
+    @patch("litellm.acompletion")
+    async def test_strict_mode_default_true_hosted_vllm(self, mock_completion):
+        language_model = LanguageModel(
+            model="hosted_vllm/Qwen/Qwen3-4B",
+            api_base="http://localhost:8000/v1",
+        )
+        messages = ChatMessages(
+            messages=[ChatMessage(role=ChatRole.USER, content="hi")]
+        )
+
+        class Answer(DataModel):
+            answer: str
+
+        mock_completion.return_value = {
+            "choices": [{"message": {"content": '{"answer":"4"}'}}]
+        }
+        await language_model(messages, schema=Answer.get_schema())
+        response_format = mock_completion.call_args.kwargs["response_format"]
+        self.assertEqual(response_format.get("strict"), True)
+
+    @patch("litellm.acompletion")
+    async def test_strict_mode_false_omits_strict_hosted_vllm(self, mock_completion):
+        language_model = LanguageModel(
+            model="hosted_vllm/Qwen/Qwen3-4B",
+            api_base="http://localhost:8000/v1",
+            strict_mode=False,
+        )
+        messages = ChatMessages(
+            messages=[ChatMessage(role=ChatRole.USER, content="hi")]
+        )
+
+        class Answer(DataModel):
+            answer: str
+
+        mock_completion.return_value = {
+            "choices": [{"message": {"content": '{"answer":"4"}'}}]
+        }
+        await language_model(messages, schema=Answer.get_schema())
+        response_format = mock_completion.call_args.kwargs["response_format"]
+        self.assertNotIn("strict", response_format)
+        self.assertNotIn("strict", response_format["json_schema"])
+
+    @patch("litellm.acompletion")
+    async def test_strict_mode_false_omits_strict_openai(self, mock_completion):
+        language_model = LanguageModel(
+            model="openai/gpt-4o-mini",
+            strict_mode=False,
+        )
+        messages = ChatMessages(
+            messages=[ChatMessage(role=ChatRole.USER, content="hi")]
+        )
+
+        class Answer(DataModel):
+            answer: str
+
+        mock_completion.return_value = {
+            "choices": [{"message": {"content": '{"answer":"4"}'}}]
+        }
+        await language_model(messages, schema=Answer.get_schema())
+        response_format = mock_completion.call_args.kwargs["response_format"]
+        self.assertNotIn("strict", response_format["json_schema"])
+
+    @patch("litellm.acompletion")
+    async def test_strict_mode_false_omits_strict_ollama(self, mock_completion):
+        language_model = LanguageModel(
+            model="ollama/mistral",
+            strict_mode=False,
+        )
+        messages = ChatMessages(
+            messages=[ChatMessage(role=ChatRole.USER, content="hi")]
+        )
+
+        class Answer(DataModel):
+            answer: str
+
+        mock_completion.return_value = {
+            "choices": [{"message": {"content": '{"answer":"4"}'}}]
+        }
+        await language_model(messages, schema=Answer.get_schema())
+        response_format = mock_completion.call_args.kwargs["response_format"]
+        self.assertNotIn("strict", response_format)
+
+    def test_strict_mode_roundtrip_via_get_config(self):
+        lm = LanguageModel(model="ollama/mistral", strict_mode=False)
+        config = lm.get_config()
+        self.assertEqual(config["strict_mode"], False)
+        restored = LanguageModel.from_config(config)
+        self.assertEqual(restored.strict_mode, False)


### PR DESCRIPTION
## Summary

Adds an opt-out for the hardcoded `"strict": true` field that `LanguageModel` currently injects into `response_format` for structured-output calls.

## Problem

Some OpenAI-compatible servers reject unknown fields in `response_format` via Pydantic's `extra_forbidden` validator. Notably, NVIDIA's **TensorRT-LLM (`trtllm-serve`)** returns:

```
BadRequestError: [{'type': 'extra_forbidden',
 'loc': ('body', 'response_format', 'strict'),
 'msg': 'Extra inputs are not permitted'}]
```

`litellm.drop_params = True` does not strip this field, so the request fails regardless of the `strict` value (True or False — the key itself is forbidden).

Today, users hitting such a server have no way to use `LanguageModel` with structured output.

## Change

Add a `strict_mode` constructor argument to `LanguageModel`:

- **Default: `True`** — preserves current behavior, no breaking change.
- **`False`** — omits the `strict` field entirely from the `response_format` payload.

```python
# Default (unchanged)
lm = synalinks.LanguageModel(model="openai/gpt-4o-mini")

# For TensorRT-LLM and similar strict-field-rejecting servers
lm = synalinks.LanguageModel(
    model="hosted_vllm/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4",
    api_base="http://my-trtllm-server/v1",
    strict_mode=False,
)
```

Also wired through `get_config()` / `from_config()` for serialization roundtrip.

## Scope

- Scope is limited to the `strict` field. No rename/alias for other servers that might use a different parameter name — that can be a separate change if needed.
- All 5 provider branches that set `strict` are covered uniformly.
- No env vars introduced; configuration stays in the constructor like all other `LanguageModel` options.

## Tests

Added 5 unit tests in `synalinks/src/language_models/language_model_test.py`:

- `test_strict_mode_default_true_hosted_vllm` — verifies default still emits `strict: true`
- `test_strict_mode_false_omits_strict_hosted_vllm`
- `test_strict_mode_false_omits_strict_openai` (covers the inside-`json_schema` variant)
- `test_strict_mode_false_omits_strict_ollama`
- `test_strict_mode_roundtrip_via_get_config`

All 10 tests in the file pass (5 existing + 5 new).

## Test plan

- [x] `uv run pytest synalinks/src/language_models/language_model_test.py -v` passes (10/10)
- [x] Default behavior preserved (existing tests unchanged)
- [x] Verified against a live TensorRT-LLM server (trtllm-serve with Nemotron-Nano) where `strict_mode=False` unblocks structured output calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)