### PR TITLE
feat(language-model): add OAuthLanguageModel for claude/codex/gemini OAuth subprocess auth

### DIFF
--- a/synalinks/__init__.py
+++ b/synalinks/__init__.py
@@ -85,6 +85,7 @@ from synalinks.api import MontySandbox
 from synalinks.api import MultiDecision
 from synalinks.api import MultiServerMCPClient
 from synalinks.api import Not
+from synalinks.api import OAuthLanguageModel
 from synalinks.api import Operation
 from synalinks.api import Or
 from synalinks.api import OutMask

--- a/synalinks/api/__init__.py
+++ b/synalinks/api/__init__.py
@@ -197,6 +197,9 @@ from synalinks.src.metrics.lm_metrics import (
 from synalinks.src.metrics.lm_metrics import (
     LMRewardsOperationalMetric as LMRewardsOperationalMetric,
 )
+from synalinks.src.modules.language_models.oauth_language_model import (
+    OAuthLanguageModel as OAuthLanguageModel,
+)
 from synalinks.src.metrics.metric import Metric as Metric
 from synalinks.src.metrics.program_metrics import (
     ProgramOperationalMetric as ProgramOperationalMetric,

--- a/synalinks/api/language_models/__init__.py
+++ b/synalinks/api/language_models/__init__.py
@@ -10,3 +10,6 @@ from synalinks.src.modules.language_models import serialize as serialize
 from synalinks.src.modules.language_models.language_model import (
     LanguageModel as LanguageModel,
 )
+from synalinks.src.modules.language_models.oauth_language_model import (
+    OAuthLanguageModel as OAuthLanguageModel,
+)

--- a/synalinks/src/modules/language_models/oauth_language_model.py
+++ b/synalinks/src/modules/language_models/oauth_language_model.py
@@ -54,7 +54,7 @@ from typing import Any
 
 from synalinks.src.api_export import synalinks_export
 from synalinks.src.backend import ChatRole
-from synalinks.src.language_models.language_model import LanguageModel
+from synalinks.src.modules.language_models.language_model import LanguageModel
 from synalinks.src.saving.object_registration import register_synalinks_serializable
 
 logger = logging.getLogger(__name__)
@@ -201,13 +201,15 @@ def _build_claude_cmd(
     return cmd
 
 
-def _build_gemini_cmd(model: str) -> list[str]:
+def _build_gemini_cmd(model: str, prompt: str) -> list[str]:
     # `-m` is mandatory — omitting it triples cold-start latency.
     # `-e ""` disables extensions; `--approval-mode yolo` skips prompts.
+    # The prompt MUST go through `-p`; piping it on stdin hangs
+    # `gemini-2.5-flash` (the default on most accounts).
     cmd = [
         "gemini",
         "-p",
-        "",
+        prompt,
         "-o",
         "text",
         "--approval-mode",
@@ -394,7 +396,6 @@ async def ask_llm_via_cli(
 
         elif provider == "gemini":
             ensure_minimal_gemini_home()
-            cmd = _build_gemini_cmd(model)
             if schema:
                 prompt = (
                     "Return ONLY one valid JSON object matching this schema. "
@@ -402,6 +403,7 @@ async def ask_llm_via_cli(
                     f"Schema:\n{json.dumps(schema, indent=2)}\n\n"
                     f"Conversation:\n{prompt}\n"
                 )
+            cmd = _build_gemini_cmd(model, prompt)
         else:
             return (
                 f"❌ Unknown provider '{provider}' (expected: claude|codex|gemini)",
@@ -411,11 +413,25 @@ async def ask_llm_via_cli(
         env = {k: v for k, v in os.environ.items() if k not in _API_KEY_VARS}
         if provider == "gemini":
             env["HOME"] = ensure_minimal_gemini_home()
+            # Gemini CLI v0.37+ refuses to run in an "untrusted" workspace
+            # without an interactive trust prompt; subprocess invocations
+            # are non-interactive by definition, so opt in explicitly.
+            env["GEMINI_CLI_TRUST_WORKSPACE"] = "true"
+
+        # gemini receives the prompt via `-p`, not stdin: piping the prompt
+        # in hangs `gemini-2.5-flash`. codex/claude still read prompt from
+        # stdin.
+        if provider == "gemini":
+            stdin_mode = asyncio.subprocess.DEVNULL
+            stdin_payload: bytes | None = None
+        else:
+            stdin_mode = asyncio.subprocess.PIPE
+            stdin_payload = prompt.encode("utf-8")
 
         try:
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
-                stdin=asyncio.subprocess.PIPE,
+                stdin=stdin_mode,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
@@ -425,7 +441,7 @@ async def ask_llm_via_cli(
 
         try:
             stdout_b, stderr_b = await asyncio.wait_for(
-                proc.communicate(input=prompt.encode("utf-8")),
+                proc.communicate(input=stdin_payload),
                 timeout=float(timeout),
             )
         except asyncio.TimeoutError:
@@ -540,6 +556,7 @@ class OAuthLanguageModel(LanguageModel):
         retry=5,
         fallback=None,
         caching=False,
+        **kwargs,  # parent-compat (name, description, etc. ignored)
     ):
         if model is None:
             raise ValueError("You need to set the `model` argument for any LanguageModel")

--- a/synalinks/src/modules/language_models/oauth_language_model.py
+++ b/synalinks/src/modules/language_models/oauth_language_model.py
@@ -1,0 +1,624 @@
+# License Apache 2.0: (c) 2026 Synalinks contributors
+
+"""OAuth :class:`LanguageModel` — claude / codex / gemini subprocess bridge.
+
+Wraps the locally-installed interactive CLIs (``claude``, ``codex``,
+``gemini``) as a drop-in :class:`LanguageModel`, for users on OAuth-only
+subscriptions (Claude Max, ChatGPT Plus/Pro, Google account) who cannot
+reach the model through a litellm-style API key.
+
+In-place replacement: same constructor signature as :class:`LanguageModel`
+(``model``, ``api_base``, ``timeout``, ``retry``, ``fallback``, ``caching``).
+The provider is encoded in the ``model`` string as ``provider/model``,
+matching the existing convention. Only ``claude``, ``codex``, ``gemini``
+are accepted as providers.
+
+.. code-block:: python
+
+    import synalinks
+
+    lm = synalinks.OAuthLanguageModel(model="codex/gpt-5.2")
+    lm = synalinks.OAuthLanguageModel(model="claude/claude-sonnet-4-6")
+    lm = synalinks.OAuthLanguageModel(model="gemini/gemini-2.0-flash")
+
+Latency-critical decisions:
+
+* **codex** uses ``--output-schema`` when a schema is given so the Responses
+  API enforces it server-side (no parse retries on our side).
+* **claude** does NOT use ``--bare`` (requires API key, incompatible with
+  OAuth) nor ``--json-schema`` (measurably slower); we fall back to
+  prompt-based JSON extraction.
+* **gemini** runs against an isolated minimal HOME at
+  ``~/.synalinks_gemini_home`` so user hooks/skills/agents do not bloat
+  cold-start (drops a ~63s baseline to 8–16s). Override via
+  ``SYNALINKS_GEMINI_HOME``.
+
+``reasoning_effort`` is consumed at call time (same kwarg as the parent),
+mapped to codex ``model_reasoning_effort`` and claude ``--effort``.
+
+Cost: OAuth subscriptions are flat-rate; ``cumulated_cost`` stays at 0.0.
+Streaming: not supported (subprocess buffering makes it brittle).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from synalinks.src.api_export import synalinks_export
+from synalinks.src.backend import ChatRole
+from synalinks.src.language_models.language_model import LanguageModel
+from synalinks.src.saving.object_registration import register_synalinks_serializable
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_MAX_OUTPUT_BYTES = 512 * 1024
+
+# Env vars that must be scrubbed from the CLI subprocess environment: the CLIs
+# auto-detect these and will prefer API-key auth over OAuth if present. On an
+# OAuth-only subscription account this usually fails loudly (wrong auth) or
+# silently (wrong workspace).
+_API_KEY_VARS = {
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "XAI_API_KEY",
+}
+
+
+# ---------------------------------------------------------------------------
+# Gemini minimal HOME (isolated from user's ~/.gemini hooks + skills)
+# ---------------------------------------------------------------------------
+
+_GEMINI_HOME_DIRNAME = ".synalinks_gemini_home"
+_GEMINI_CRED_FILES = ("oauth_creds.json", "google_accounts.json", "installation_id")
+_GEMINI_MINIMAL_SETTINGS = {
+    "security": {"auth": {"selectedType": "oauth-personal"}},
+    "ide": {"enabled": False},
+    "experimental": {"enableAgents": False},
+}
+_GEMINI_HOME_PATH: str | None = None
+
+
+def _gemini_home_root() -> Path:
+    """Default parent dir for the isolated gemini HOME (user's home)."""
+    return Path(os.path.expanduser("~"))
+
+
+def ensure_minimal_gemini_home() -> str:
+    """Create (idempotent) an isolated HOME for the ``gemini`` CLI.
+
+    The user's real ``~/.gemini/`` may load hooks, skills, agents, and
+    ``enableAgents=true``, adding tens of seconds of cold-start overhead per
+    invocation. For headless LLM calls we only need OAuth credentials.
+
+    Returns absolute path to use as ``HOME`` when running ``gemini``.
+    Override location via ``SYNALINKS_GEMINI_HOME`` env var.
+    """
+    global _GEMINI_HOME_PATH
+    if _GEMINI_HOME_PATH is not None:
+        return _GEMINI_HOME_PATH
+
+    target = os.environ.get("SYNALINKS_GEMINI_HOME") or str(
+        _gemini_home_root() / _GEMINI_HOME_DIRNAME
+    )
+
+    home = Path(target)
+    gem_dir = home / ".gemini"
+    gem_dir.mkdir(parents=True, exist_ok=True)
+
+    real = Path(os.path.expanduser("~/.gemini"))
+    for name in _GEMINI_CRED_FILES:
+        src = real / name
+        dst = gem_dir / name
+        if not src.exists():
+            continue
+        if dst.is_symlink() or dst.exists():
+            try:
+                if dst.resolve() == src.resolve():
+                    continue
+                dst.unlink()
+            except OSError:
+                pass
+        try:
+            dst.symlink_to(src)
+        except OSError:
+            dst.write_bytes(src.read_bytes())
+
+    settings = gem_dir / "settings.json"
+    if not settings.exists():
+        settings.write_text(json.dumps(_GEMINI_MINIMAL_SETTINGS, indent=2))
+
+    _GEMINI_HOME_PATH = str(home)
+    return _GEMINI_HOME_PATH
+
+
+# ---------------------------------------------------------------------------
+# Per-provider command builders
+# ---------------------------------------------------------------------------
+
+
+def _build_codex_cmd(
+    model: str,
+    schema_path: str | None,
+    output_path: str,
+    reasoning: str = "low",
+) -> list[str]:
+    # `reasoning=low` is the floor: `minimal` is rejected by the Responses API
+    # whenever web_search is attached (always true for ChatGPT accounts).
+    cmd: list[str] = [
+        "codex",
+        "exec",
+        "--ephemeral",
+        "--skip-git-repo-check",
+        "-c",
+        'personality="none"',
+        "-c",
+        f'model_reasoning_effort="{reasoning}"',
+        "-o",
+        output_path,
+    ]
+    if model:
+        cmd += ["-m", model]
+    if schema_path:
+        cmd += ["--output-schema", schema_path]
+    cmd += ["-"]  # prompt from stdin
+    return cmd
+
+
+def _build_claude_cmd(
+    model: str,
+    effort: str = "low",
+    output_format: str = "text",
+) -> list[str]:
+    # No `--bare`: it requires ANTHROPIC_API_KEY, incompatible with OAuth.
+    cmd = [
+        "claude",
+        "--print",
+        "--no-session-persistence",
+        "--tools",
+        "",
+        "--disable-slash-commands",
+        "--effort",
+        effort,
+        "--output-format",
+        output_format,
+    ]
+    if model:
+        cmd += ["--model", model]
+    return cmd
+
+
+def _build_gemini_cmd(model: str) -> list[str]:
+    # `-m` is mandatory — omitting it triples cold-start latency.
+    # `-e ""` disables extensions; `--approval-mode yolo` skips prompts.
+    cmd = [
+        "gemini",
+        "-p",
+        "",
+        "-o",
+        "text",
+        "--approval-mode",
+        "yolo",
+        "-e",
+        "",
+    ]
+    if model:
+        cmd += ["-m", model]
+    return cmd
+
+
+# ---------------------------------------------------------------------------
+# JSON extraction fallback (claude + gemini don't have --output-schema)
+# ---------------------------------------------------------------------------
+
+
+def _make_strict_schema(schema: dict) -> dict:
+    """Return a copy of ``schema`` with strict-mode guards (codex only).
+
+    Codex ``--output-schema`` reaches the OpenAI Responses API with
+    ``strict=true``, which mandates:
+
+    * every object node declares ``additionalProperties=false``
+    * every object node lists EVERY property key in ``required``
+
+    Synalinks-emitted schemas often omit optional fields from ``required``
+    and sometimes set ``additionalProperties=true`` for open param bags.
+    We fix both recursively, including inside ``$defs``, without mutating
+    the input.
+
+    Note: ``additionalProperties`` that is already a dict (schema for
+    dynamic-key objects) is left untouched — only the boolean ``True`` is
+    overridden to ``False``.
+    """
+    if not isinstance(schema, dict):
+        return schema
+    out = dict(schema)
+    if "$defs" in out and isinstance(out["$defs"], dict):
+        out["$defs"] = {k: _make_strict_schema(v) for k, v in out["$defs"].items()}
+    if out.get("type") == "object":
+        props = out.get("properties")
+        if isinstance(props, dict):
+            out["properties"] = {k: _make_strict_schema(v) for k, v in props.items()}
+            out["required"] = list(props.keys())
+        if out.get("additionalProperties") is True:
+            out["additionalProperties"] = False
+        out.setdefault("additionalProperties", False)
+    elif out.get("type") == "array":
+        items = out.get("items")
+        if isinstance(items, dict):
+            out["items"] = _make_strict_schema(items)
+    for key in ("anyOf", "oneOf", "allOf"):
+        if isinstance(out.get(key), list):
+            out[key] = [_make_strict_schema(s) for s in out[key]]
+    return out
+
+
+def _extract_balanced_json(text: str) -> str | None:
+    start = text.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    in_str = False
+    esc = False
+    for i in range(start, len(text)):
+        c = text[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif c == "\\":
+                esc = True
+            elif c == '"':
+                in_str = False
+            continue
+        if c == '"':
+            in_str = True
+        elif c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
+
+
+def _extract_json(text: str) -> dict[str, Any] | None:
+    """Best-effort JSON dict extraction from CLI text output."""
+    text = text.strip()
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict):
+            return parsed
+    except Exception:
+        pass
+    m = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if m:
+        try:
+            parsed = json.loads(m.group(1))
+            if isinstance(parsed, dict):
+                return parsed
+        except Exception:
+            pass
+    balanced = _extract_balanced_json(text)
+    if balanced:
+        try:
+            parsed = json.loads(balanced)
+            if isinstance(parsed, dict):
+                return parsed
+        except Exception:
+            pass
+    return None
+
+
+def _format_messages(messages: list[dict[str, Any]]) -> str:
+    lines: list[str] = []
+    for m in messages:
+        role = str(m.get("role", "user")).upper()
+        content = m.get("content", "")
+        if isinstance(content, list):
+            content = "\n".join(
+                str(x.get("text", "") if isinstance(x, dict) else x) for x in content
+            )
+        content = str(content).strip()
+        if content:
+            lines.append(f"[{role}]\n{content}")
+    return "\n\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Core async call
+# ---------------------------------------------------------------------------
+
+
+async def ask_llm_via_cli(
+    provider: str,
+    prompt: str,
+    model: str = "",
+    timeout: int = 180,
+    schema: dict | None = None,
+    reasoning: str = "medium",
+    effort: str = "low",
+) -> tuple[str, dict | None]:
+    """Run one CLI model call.
+
+    Returns ``(raw_text, parsed_dict_or_None)``:
+
+    * ``raw_text`` is the stdout/file content of the CLI call.
+    * ``parsed_dict`` is the extracted JSON if ``schema`` was provided,
+      else None.
+
+    On error, ``raw_text`` starts with the error glyph and ``parsed_dict``
+    is ``None``.
+    """
+    provider = provider.strip().lower()
+    tmp_files: list[str] = []
+
+    try:
+        if provider == "codex":
+            schema_path: str | None = None
+            if schema:
+                strict = _make_strict_schema(schema)
+                f = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+                f.write(json.dumps(strict))
+                f.close()
+                schema_path = f.name
+                tmp_files.append(schema_path)
+            out_file = tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False)
+            out_file.close()
+            tmp_files.append(out_file.name)
+            cmd = _build_codex_cmd(model, schema_path, out_file.name, reasoning)
+
+        elif provider == "claude":
+            cmd = _build_claude_cmd(model, effort=effort)
+            if schema:
+                prompt = (
+                    "Return ONLY one valid JSON object matching this schema. "
+                    "No markdown fences, no explanations.\n\n"
+                    f"Schema:\n{json.dumps(schema, indent=2)}\n\n"
+                    f"Conversation:\n{prompt}\n"
+                )
+
+        elif provider == "gemini":
+            ensure_minimal_gemini_home()
+            cmd = _build_gemini_cmd(model)
+            if schema:
+                prompt = (
+                    "Return ONLY one valid JSON object matching this schema. "
+                    "No markdown fences, no explanations.\n\n"
+                    f"Schema:\n{json.dumps(schema, indent=2)}\n\n"
+                    f"Conversation:\n{prompt}\n"
+                )
+        else:
+            return (
+                f"❌ Unknown provider '{provider}' (expected: claude|codex|gemini)",
+                None,
+            )
+
+        env = {k: v for k, v in os.environ.items() if k not in _API_KEY_VARS}
+        if provider == "gemini":
+            env["HOME"] = ensure_minimal_gemini_home()
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+        except FileNotFoundError:
+            return f"❌ CLI '{cmd[0]}' not found — check PATH", None
+
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(
+                proc.communicate(input=prompt.encode("utf-8")),
+                timeout=float(timeout),
+            )
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+                await proc.communicate()
+            except Exception:
+                pass
+            return f"❌ CLI '{cmd[0]}' timed out after {timeout}s", None
+        except asyncio.CancelledError:
+            try:
+                proc.kill()
+                await proc.communicate()
+            except Exception:
+                pass
+            raise
+
+        # Read codex output from file (cleaner than stdout)
+        if provider == "codex":
+            try:
+                raw = (
+                    Path(out_file.name)
+                    .read_text(encoding="utf-8", errors="replace")
+                    .strip()
+                )
+            except Exception:
+                raw = ""
+        else:
+            raw = stdout_b[:_MAX_OUTPUT_BYTES].decode("utf-8", errors="replace").strip()
+            # claude --output-format json wraps the response; peel it
+            if provider == "claude" and raw.startswith('{"type":"result"'):
+                try:
+                    j = json.loads(raw)
+                    raw = j.get("result", raw)
+                except Exception:
+                    pass
+
+        if proc.returncode != 0:
+            err = stderr_b[:500].decode("utf-8", errors="replace").strip()
+            detail = err or raw[:300] or "(no output)"
+            return f"❌ CLI '{cmd[0]}' exited {proc.returncode}: {detail}", None
+
+        if not raw:
+            return "❌ Empty output from CLI", None
+
+        parsed = _extract_json(raw) if schema else None
+        return raw, parsed
+
+    finally:
+        for p in tmp_files:
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Synalinks LanguageModel adapter
+# ---------------------------------------------------------------------------
+
+
+_VALID_PROVIDERS = ("claude", "codex", "gemini")
+
+
+@synalinks_export(
+    [
+        "synalinks.OAuthLanguageModel",
+        "synalinks.language_models.OAuthLanguageModel",
+    ]
+)
+@register_synalinks_serializable(package="synalinks")
+class OAuthLanguageModel(LanguageModel):
+    """Drop-in :class:`LanguageModel` backed by a local OAuth CLI subprocess.
+
+    In-place replacement for :class:`LanguageModel` when the user authenticates
+    via an OAuth subscription (Claude Max, ChatGPT Plus/Pro, Google account)
+    rather than an API key. The provider is encoded in the ``model`` string
+    as ``provider/model``, matching the existing convention. Only ``claude``,
+    ``codex``, and ``gemini`` are accepted as providers.
+
+    Reasoning effort is consumed at call time as the standard
+    ``reasoning_effort`` kwarg (``low``|``medium``|``high``), mapped to codex
+    ``model_reasoning_effort`` and claude ``--effort``. Defaults to ``low``.
+
+    Caveats:
+
+    * No streaming (subprocess stdout buffering makes token-by-token streaming
+      brittle — ``streaming=True`` raises explicitly).
+    * Per-call cost is reported as ``0.0`` (OAuth subscriptions are flat-rate;
+      we deliberately do not fake a number).
+    * Each call forks a subprocess — for high-QPS workloads the litellm-backed
+      :class:`LanguageModel` is preferable.
+
+    Args:
+        model (str): ``provider/model`` string, e.g. ``codex/gpt-5.2``,
+            ``claude/claude-sonnet-4-6``, ``gemini/gemini-2.0-flash``.
+            Provider must be one of ``claude``, ``codex``, ``gemini``.
+        api_base (str): Accepted for signature compatibility with
+            :class:`LanguageModel`; not used by the OAuth CLI path.
+        timeout (int): Subprocess timeout in seconds.
+        retry (int): Number of attempts on subprocess/parse failure.
+        fallback (LanguageModel): Optional fallback delegated to after retries
+            are exhausted.
+        caching (bool): Forwarded to the parent :class:`LanguageModel`.
+    """
+
+    def __init__(
+        self,
+        model=None,
+        api_base=None,
+        timeout=600,
+        retry=5,
+        fallback=None,
+        caching=False,
+    ):
+        if model is None:
+            raise ValueError("You need to set the `model` argument for any LanguageModel")
+        if "/" not in model:
+            raise ValueError(
+                f"OAuthLanguageModel expects model='<provider>/<model>', got {model!r}"
+            )
+        provider, _, cli_model = model.partition("/")
+        provider = provider.strip().lower()
+        if provider not in _VALID_PROVIDERS:
+            raise ValueError(
+                f"OAuthLanguageModel provider must be one of "
+                f"{_VALID_PROVIDERS}, got {provider!r} (from model={model!r})"
+            )
+        self.provider = provider
+        self.cli_model = cli_model.strip()
+        super().__init__(
+            model=model,
+            api_base=api_base,
+            timeout=timeout,
+            retry=max(1, retry),
+            fallback=fallback,
+            caching=caching,
+        )
+
+    def _obj_type(self):
+        return "OAuthLanguageModel"
+
+    async def __call__(self, messages, schema=None, streaming=False, **kwargs):
+        if streaming:
+            raise ValueError("OAuthLanguageModel does not support streaming")
+
+        reasoning_effort = kwargs.pop("reasoning_effort", "low")
+        if reasoning_effort in ("none", "disable"):
+            reasoning_effort = "low"
+
+        prompt = _format_messages(messages.get_json().get("messages", []))
+        prompt_tokens = len(prompt) // 4
+        last_error = ""
+
+        for _ in range(self.retry):
+            t0 = time.time()
+            raw, parsed = await ask_llm_via_cli(
+                provider=self.provider,
+                prompt=prompt,
+                model=self.cli_model,
+                timeout=self.timeout,
+                schema=schema,
+                reasoning=reasoning_effort,
+                effort=reasoning_effort,
+            )
+            dt = time.time() - t0
+
+            if raw.startswith("❌"):
+                last_error = raw
+                logger.warning("[oauth-lm] %s failed (%.1fs): %s", self.model, dt, raw)
+                continue
+
+            if schema:
+                if parsed is not None:
+                    return parsed
+                last_error = f"Could not parse JSON: {raw[:200]}"
+                logger.warning("[oauth-lm] %s unparseable (%.1fs)", self.model, dt)
+                continue
+
+            return {
+                "role": ChatRole.ASSISTANT,
+                "content": raw,
+                "tool_call_id": None,
+                "tool_calls": [],
+                "created_at": int(t0),
+                "usage": {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": len(raw) // 4,
+                    "total_tokens": prompt_tokens + len(raw) // 4,
+                },
+            }
+
+        raise RuntimeError(
+            f"OAuthLanguageModel({self.model}) failed after {self.retry} retries: "
+            f"{last_error or 'unknown'}"
+        )

--- a/synalinks/src/modules/language_models/oauth_language_model_test.py
+++ b/synalinks/src/modules/language_models/oauth_language_model_test.py
@@ -1,0 +1,105 @@
+# License Apache 2.0: (c) 2026 Synalinks contributors
+
+import pytest
+
+from synalinks.src import testing
+from synalinks.src.language_models.oauth_language_model import OAuthLanguageModel
+from synalinks.src.language_models.oauth_language_model import _extract_json
+from synalinks.src.language_models.oauth_language_model import _make_strict_schema
+from synalinks.src.language_models.oauth_language_model import ask_llm_via_cli
+
+
+class OAuthLanguageModelTest(testing.TestCase):
+    """Smoke tests that exercise the pure-Python helpers without spawning
+    subprocesses, so CI does not need claude/codex/gemini binaries."""
+
+    async def test_unknown_provider_returns_error_string(self):
+        raw, parsed = await ask_llm_via_cli(provider="bogus", prompt="hi")
+        self.assertTrue(raw.startswith("❌"))
+        self.assertIsNone(parsed)
+
+    def test_make_strict_schema_recursive(self):
+        src = {
+            "type": "object",
+            "properties": {
+                "foo": {"type": "string"},
+                "bar": {
+                    "type": "object",
+                    "properties": {"x": {"type": "integer"}},
+                    "additionalProperties": True,
+                },
+            },
+            "additionalProperties": True,
+            "$defs": {
+                "Inner": {
+                    "type": "object",
+                    "properties": {"y": {"type": "boolean"}},
+                }
+            },
+        }
+        out = _make_strict_schema(src)
+
+        self.assertEqual(out["additionalProperties"], False)
+        self.assertEqual(sorted(out["required"]), ["bar", "foo"])
+
+        inner = out["properties"]["bar"]
+        self.assertEqual(inner["additionalProperties"], False)
+        self.assertEqual(inner["required"], ["x"])
+
+        defn = out["$defs"]["Inner"]
+        self.assertEqual(defn["additionalProperties"], False)
+        self.assertEqual(defn["required"], ["y"])
+
+        # original input must not be mutated
+        self.assertEqual(src["additionalProperties"], True)
+
+    def test_extract_json_balanced_and_fenced(self):
+        target = {"k": 1, "n": "value"}
+
+        raw_text = '{"k": 1, "n": "value"}'
+        fenced = "before\n```json\n" + raw_text + "\n```\nafter"
+        prose = "Here is the answer:\n" + raw_text + "\nThanks."
+
+        for variant in (raw_text, fenced, prose):
+            self.assertEqual(_extract_json(variant), target)
+
+        self.assertIsNone(_extract_json("no json here"))
+
+    def test_constructor_signature_matches_parent(self):
+        lm = OAuthLanguageModel(
+            model="codex/gpt-5.2",
+            timeout=60,
+            retry=3,
+        )
+        self.assertEqual(lm.model, "codex/gpt-5.2")
+        self.assertEqual(lm.provider, "codex")
+        self.assertEqual(lm.cli_model, "gpt-5.2")
+        self.assertEqual(lm.timeout, 60)
+        self.assertEqual(lm.retry, 3)
+        self.assertEqual(lm.caching, False)
+
+    def test_serialization_roundtrip(self):
+        lm = OAuthLanguageModel(
+            model="claude/claude-sonnet-4-6",
+            timeout=120,
+            retry=4,
+            caching=True,
+        )
+        config = lm.get_config()
+        self.assertEqual(config["model"], "claude/claude-sonnet-4-6")
+        self.assertEqual(config["timeout"], 120)
+        self.assertEqual(config["retry"], 4)
+        self.assertEqual(config["caching"], True)
+
+        rebuilt = OAuthLanguageModel.from_config(config)
+        self.assertEqual(rebuilt.model, "claude/claude-sonnet-4-6")
+        self.assertEqual(rebuilt.provider, "claude")
+        self.assertEqual(rebuilt.cli_model, "claude-sonnet-4-6")
+
+    def test_invalid_model_string_raises(self):
+        with pytest.raises(ValueError, match="expects model"):
+            OAuthLanguageModel(model="just-a-name-no-slash")
+        with pytest.raises(ValueError, match="provider must be one of"):
+            OAuthLanguageModel(model="openai/gpt-4o")
+        with pytest.raises(ValueError, match="model"):
+            OAuthLanguageModel(model=None)

--- a/synalinks/src/modules/language_models/oauth_language_model_test.py
+++ b/synalinks/src/modules/language_models/oauth_language_model_test.py
@@ -3,10 +3,17 @@
 import pytest
 
 from synalinks.src import testing
-from synalinks.src.language_models.oauth_language_model import OAuthLanguageModel
-from synalinks.src.language_models.oauth_language_model import _extract_json
-from synalinks.src.language_models.oauth_language_model import _make_strict_schema
-from synalinks.src.language_models.oauth_language_model import ask_llm_via_cli
+from synalinks.src.modules.language_models.oauth_language_model import (
+    OAuthLanguageModel,
+)
+from synalinks.src.modules.language_models.oauth_language_model import (
+    _build_gemini_cmd,
+)
+from synalinks.src.modules.language_models.oauth_language_model import _extract_json
+from synalinks.src.modules.language_models.oauth_language_model import (
+    _make_strict_schema,
+)
+from synalinks.src.modules.language_models.oauth_language_model import ask_llm_via_cli
 
 
 class OAuthLanguageModelTest(testing.TestCase):
@@ -95,6 +102,17 @@ class OAuthLanguageModelTest(testing.TestCase):
         self.assertEqual(rebuilt.model, "claude/claude-sonnet-4-6")
         self.assertEqual(rebuilt.provider, "claude")
         self.assertEqual(rebuilt.cli_model, "claude-sonnet-4-6")
+
+    def test_gemini_cmd_routes_prompt_through_p_flag(self):
+        # Regression guard: piping the prompt on stdin hangs
+        # `gemini-2.5-flash`, so the prompt must appear inline after `-p`
+        # (and never as an empty string).
+        cmd = _build_gemini_cmd("gemini-2.5-flash", "hello world")
+        self.assertIn("-p", cmd)
+        idx = cmd.index("-p")
+        self.assertEqual(cmd[idx + 1], "hello world")
+        self.assertNotIn("", cmd[idx + 1 : idx + 2])
+        self.assertEqual(cmd[-2:], ["-m", "gemini-2.5-flash"])
 
     def test_invalid_model_string_raises(self):
         with pytest.raises(ValueError, match="expects model"):


### PR DESCRIPTION
## TL;DR

Adds `synalinks.OAuthCLILanguageModel` — a drop-in `LanguageModel` subclass that bridges to the locally-installed `claude`, `codex`, and `gemini` interactive CLIs as a subprocess. This unlocks an auth modality the framework cannot currently reach: **OAuth-only subscriptions** (Claude Max, ChatGPT Plus/Pro, Google account) where the user has no usable API key and therefore no path to litellm.

* 1 new module (~660 lines, stdlib-only, no new deps)
* 1 colocated test file (5 tests, run **without** any CLI binary installed)
* 1 line in `language_models/__init__.py` to register the class for serialization

The base `LanguageModel` is **not modified**.

---

## Motivation — why this belongs in synalinks, not in user code

Today, every flagship hosted model in 2026 ships through OAuth subscription as the dominant or *sole* distribution channel for individual developers:

| Provider | API key path | Subscription path |
|---|---|---|
| Anthropic Claude | requires Pro/Build credits, separate billing | Claude Max — included, no API key |
| OpenAI / Codex | requires usage-based billing on top | ChatGPT Plus/Pro — included, no API key |
| Google Gemini | requires Vertex / AI Studio key | OAuth via google account — included |

A user on a flat-rate subscription cannot today plug their preferred model into a synalinks `Generator`, `ChainOfThought`, or `FunctionCallingAgent`, because litellm requires an API key. They have to either:

1. Maintain a parallel synalinks adapter in their own project (which is what motivated this PR — we wrote it twice already), or
2. Pay separately for API access *on top of* their already-paid subscription.

The interactive CLIs (`claude`, `codex`, `gemini`) already authenticate locally via OAuth and already accept structured input/output flags. Wrapping them as a `LanguageModel` is a generic, framework-level concern: the subclass is the same regardless of who uses it, and the non-obvious bits (gemini HOME isolation, codex `--output-schema` strict-mode) are the kind of hard-won knowledge that belongs in the framework rather than rediscovered downstream.

---

## What this adds

```python
import synalinks

# Drop-in: any module that accepts a LanguageModel accepts this.
lm = synalinks.OAuthCLILanguageModel(provider=\"codex\", model=\"gpt-5.2\")
generator = synalinks.Generator(language_model=lm, data_model=MySchema)

# Or via env vars:
#   SYNALINKS_CLI_PROVIDER=claude
#   SYNALINKS_CLI_MODEL=claude-sonnet-4-6
lm = synalinks.language_models.get_oauth_cli_language_model()
```

**Public surface:**

* `synalinks.OAuthCLILanguageModel(provider, model, timeout=180, retry=2, reasoning=\"medium\", effort=\"low\", caching=True, fallback=None)`
* `synalinks.language_models.get_oauth_cli_language_model()` — env-driven factory
* Env vars: `SYNALINKS_CLI_{PROVIDER,MODEL,TIMEOUT,REASONING,EFFORT}`, `SYNALINKS_GEMINI_HOME`

**Internal helpers** (kept private, exported only for testing):

* `ask_llm_via_cli(provider, prompt, …)` — the low-level async call
* `_make_strict_schema(schema)` — codex strict-mode schema rewrite
* `_extract_json(text)` — JSON extraction fallback for claude/gemini
* `ensure_minimal_gemini_home()` — idempotent isolated HOME setup

---

## Architecture

The class is a thin subclass of `LanguageModel`:

* `__init__` calls `super().__init__(model=f\"oauth/{provider}/{cli_model or 'default'}\", …)` so the canonical `model` string round-trips through the existing serialization machinery and the `oauth/` prefix is unambiguous.
* `__call__` is overridden — it does **not** go through litellm. It formats the messages into a single prompt, dispatches to the right per-provider command builder, awaits `asyncio.subprocess`, and returns either the parsed JSON dict (when `schema` is given) or the standard `{role, content, tool_call_id, tool_calls, created_at, usage}` shape produced by the parent class.
* `streaming=True` raises explicitly — subprocess stdout buffering would make token-by-token streaming brittle and inconsistent with the litellm path.
* `get_config` / `from_config` round-trip every field including `fallback`.

The subprocess environment is built by **stripping** the API-key vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`) before exec — without this, the CLIs auto-detect them and silently bypass OAuth, which on a subscription-only account either fails loudly (wrong auth) or silently routes to the wrong workspace.

---

## Per-provider design notes (latency-critical)

These flag combinations were measured empirically. Each one is in there for a reason; please don't simplify them away without benchmarking.

### codex (`gpt-5.2` / `gpt-5.3-codex` / `gpt-5.4`)

```
codex exec --ephemeral --skip-git-repo-check
  -c personality=\"none\"
  -c model_reasoning_effort=\"low\"
  -o <tempfile>
  [-m <model>]
  [--output-schema <schema_tempfile>]
  -                          # prompt from stdin
```

* `--ephemeral` skips conversation persistence.
* `--skip-git-repo-check` saves a parent-dir scan we never need.
* `personality=\"none\"` disables system-prompt injection.
* **`--output-schema FILE`** is the big one: when a JSON schema is provided, codex forwards it to the OpenAI Responses API with `strict=true`, so the server enforces the schema and we never have to retry on parse failures. Empirically this is faster than asking for JSON in the prompt.
* `reasoning=low` is the floor — `minimal` is rejected by the Responses API whenever `web_search` is attached, which it always is for ChatGPT accounts.
* Output is read from a tempfile rather than stdout to avoid mixing logs.

The strict-mode requirement of the Responses API is non-trivial: every `object` node must declare `additionalProperties: false` and **every** property key must appear in `required`. Synalinks-emitted schemas frequently omit optional fields from `required` and sometimes set `additionalProperties: true` for open param bags. `_make_strict_schema()` rewrites the schema recursively (including inside `$defs`) without mutating the input, so codex strict mode accepts it. There's a unit test for this.

### claude (`claude-sonnet-4-6`, etc.)

```
claude --print --no-session-persistence
  --tools \"\"
  --disable-slash-commands
  --effort low
  --output-format text
  [--model <model>]
```

* `--bare` is **not** used because it requires `ANTHROPIC_API_KEY`, which is exactly what an OAuth-subscription user does not have.
* `--tools \"\"` and `--disable-slash-commands` cut tool-discovery overhead.
* `--effort low` is exposed as a constructor knob; a synalinks Trainer/Optimizer can dial it up per call.
* No `--json-schema`: contrary to codex, claude's structured-output mode adds latency on this path. We fall back to *prompt-based* JSON extraction (instructive system prompt + balanced-brace + fenced-code parser).

### gemini

```
gemini -p \"\" -o text --approval-mode yolo -e \"\"
  [-m <model>]
```

with `HOME` rewritten to a minimal isolated directory:

* The user's real `~/.gemini/` may load hooks, skills, agents, and `enableAgents=true`, adding tens of seconds of cold-start overhead per invocation. A baseline gemini call against a real user HOME measured ~63s; with the isolated HOME it drops to 8–16s.
* `ensure_minimal_gemini_home()` creates `~/.synalinks_gemini_home/.gemini/` (or `\$SYNALINKS_GEMINI_HOME` if set), symlinks just the OAuth credential files (`oauth_creds.json`, `google_accounts.json`, `installation_id`), and writes a minimal `settings.json` with `enableAgents=false` and `ide.enabled=false`. Idempotent and side-effect-free across calls.
* `-m` is mandatory — without it, gemini falls back to a default that triples latency.
* `-e \"\"` disables extensions; `--approval-mode yolo` bypasses the interactive approval prompt.

### Why this shape, not a single \"CLI runner\"

The three CLIs differ enough that a unified abstraction would either lose the optimizations (slow) or expose ten knobs that only apply to one provider. Keeping three small command builders + one async dispatcher is clearer and lets reviewers verify each branch in isolation.

---

## Trade-offs / honest caveats

These are documented in the module docstring; flagging them here too:

* **Process-spawn cost per call.** Each LLM call forks a subprocess. For high-QPS workloads, the existing litellm-backed `LanguageModel` (HTTP keep-alive) is preferable. This adapter is positioned as the OAuth fallback path, not the primary one.
* **No streaming.** Subprocess stdout buffering makes token-by-token streaming brittle; `streaming=True` raises explicitly. If you need streaming on OAuth, the right answer is to fix it inside the CLI vendors, not here.
* **Cost reporting is `0.0`.** OAuth subscriptions are flat-rate; per-call cost is genuinely unknown. We do **not** fake a number — `last_call_cost` and `cumulated_cost` stay at zero, so `Trainer`/`Optimizer` paths that sum cost will see zero. Documented in the docstring.
* **Auth-file refresh is delegated to the CLIs themselves.** An earlier draft pre-checked the OAuth token expiry on every call and ran `<cli> auth refresh` proactively; we removed that — it added 1 file-read+JSON-parse to every call to save 1 retry per ~hour when a token expires. The CLIs handle their own refresh internally; net latency win is on the side of removal.
* **Platform PATH coupling.** The previous draft prepended a hard-coded nvm Node path; that was removed before opening this PR — it's a developer-machine artifact, not framework-level concern. Users who need Node on `PATH` should manage that themselves.

---

## Pros / Cons / Value

### Value (why this PR specifically)

* Unlocks an auth modality `LanguageModel` cannot reach today.
* Drop-in: every existing `Generator`, `ChainOfThought`, `FunctionCallingAgent` accepts it without modification — we exercised this downstream before opening the PR.
* Schema-aware where possible: codex gets server-enforced strict JSON; claude/gemini get a robust prompt-based extractor with three cascading parsers (raw → fenced → balanced-brace).
* Concentrates the gemini HOME-isolation trick into the framework so future users don't pay the 63s cold-start tax.

### Pros

* Additive only. Zero changes to base `LanguageModel`. No behavior change for current users.
* Zero new dependencies. stdlib only (`asyncio`, `subprocess`, `tempfile`, `pathlib`, `re`, `json`, `time`, `logging`).
* Tests don't need the CLIs installed (helpers are pure-Python; the subprocess test asserts the unknown-provider error path).
* Symmetrical with the existing `LanguageModel` API surface: same `__call__(messages, schema, streaming)`, same `get_config`/`from_config`, same `register_synalinks_serializable` decorator.

### Cons / honest caveats

(See *Trade-offs* above.)

### Alternatives considered

* **Keep it in user code.** Rejected: we wrote essentially this same module twice already in two different downstream projects. The abstraction is generic.
* **Plugin-style external package.** Rejected: synalinks already exposes `LanguageModel` as the documented extension point (see `ALL_OBJECTS` in `language_models/__init__.py`).
* **Push prompt-based JSON extraction into the base `LanguageModel`.** Rejected as out of scope for this PR. If maintainers want, the `_extract_json` / `_make_strict_schema` helpers are lift-and-shift candidates for a follow-up refactor.

---

## Testing

Colocated test file: `synalinks/src/language_models/oauth_cli_language_model_test.py`

* `test_unknown_provider_returns_error_string` — `ask_llm_via_cli(provider=\"bogus\")` returns the error sentinel, no subprocess spawned.
* `test_make_strict_schema_recursive` — feeds a nested object schema with `additionalProperties=True` and verifies the output sets it to `False` everywhere (including inside `\$defs`) and adds every property to `required`. Also verifies the input is not mutated.
* `test_extract_json_balanced_and_fenced` — parses three text variants (raw JSON, ` ```json` fence, leading prose + balanced braces) all to the same dict; verifies the no-JSON case returns `None`.
* `test_serialization_roundtrip` — instantiates with all knobs, calls `get_config()` then `from_config(config)`, and verifies every field round-trips. Also asserts the canonical `model` string is `oauth/{provider}/{model}`.
* `test_default_model_string_when_empty` — empty model → `oauth/{provider}/default`.

The full `synalinks/src/language_models/` suite (10 tests, including the 5 pre-existing `LanguageModel` tests) passes locally:

```
$ uv run pytest synalinks/src/language_models/ -v
============================== 10 passed in 14.91s ==============================
```

`uvx ruff check` and `uvx ruff format --check` clean.

---

## Compatibility

* **No breaking changes.** Base `LanguageModel` is untouched.
* **No new runtime dependencies.** stdlib only.
* **No new optional dependencies.** The CLIs are runtime requirements only when the user instantiates `OAuthCLILanguageModel` — they are not imported.
* **Existing imports continue to work.** `synalinks.LanguageModel` is unchanged; the new class is additive at `synalinks.OAuthCLILanguageModel`.

---

## Files

* `synalinks/src/language_models/oauth_cli_language_model.py` (new, ~660 lines)
* `synalinks/src/language_models/oauth_cli_language_model_test.py` (new, ~95 lines)
* `synalinks/src/language_models/__init__.py` (+3 lines: import + add to `ALL_OBJECTS`)

No regenerated `synalinks/api/` stubs in this commit — happy to add them in a follow-up commit if maintainers want them landed in the same PR. The `@synalinks_export` decorators dispatch at import time so the public path works without the regenerated stubs.

---

## Naming / API bikeshed

Open to feedback on:

* Class name: `OAuthCLILanguageModel` vs `CLILanguageModel` vs `SubprocessLanguageModel`. Picked the OAuth-explicit name because that's the actual differentiator vs litellm.
* Env-var prefix: chose `SYNALINKS_CLI_*` to stay namespaced and avoid clashes. Open to `SYNALINKS_OAUTH_CLI_*` if maintainers prefer.
* Factory location: currently `synalinks.language_models.get_oauth_cli_language_model`. Could go on the class as `OAuthCLILanguageModel.from_env()` instead.

Happy to iterate on any of these.