### PR TITLE
feat(metrics): failure/latency metrics + wall-clock throughput

### DIFF
--- a/synalinks/api/metrics/__init__.py
+++ b/synalinks/api/metrics/__init__.py
@@ -13,8 +13,12 @@ from synalinks.src.metrics.accuracy_metrics import (
     CategoricalAccuracy as CategoricalAccuracy,
 )
 from synalinks.src.metrics.em_metrics import (
+    AvgEmbeddingCachedTokensPerCall as AvgEmbeddingCachedTokensPerCall,
+)
+from synalinks.src.metrics.em_metrics import (
     AvgEmbeddingCostPerCall as AvgEmbeddingCostPerCall,
 )
+from synalinks.src.metrics.em_metrics import AvgEmbeddingLatency as AvgEmbeddingLatency
 from synalinks.src.metrics.em_metrics import (
     AvgEmbeddingTokensPerCall as AvgEmbeddingTokensPerCall,
 )
@@ -22,7 +26,13 @@ from synalinks.src.metrics.em_metrics import (
     AvgEmbeddingVectorsPerCall as AvgEmbeddingVectorsPerCall,
 )
 from synalinks.src.metrics.em_metrics import (
+    AvgOptimizerEmbeddingCachedTokensPerCall as AvgOptimizerEmbeddingCachedTokensPerCall,
+)
+from synalinks.src.metrics.em_metrics import (
     AvgOptimizerEmbeddingCostPerCall as AvgOptimizerEmbeddingCostPerCall,
+)
+from synalinks.src.metrics.em_metrics import (
+    AvgOptimizerEmbeddingLatency as AvgOptimizerEmbeddingLatency,
 )
 from synalinks.src.metrics.em_metrics import (
     AvgOptimizerEmbeddingTokensPerCall as AvgOptimizerEmbeddingTokensPerCall,
@@ -31,7 +41,13 @@ from synalinks.src.metrics.em_metrics import (
     AvgOptimizerEmbeddingVectorsPerCall as AvgOptimizerEmbeddingVectorsPerCall,
 )
 from synalinks.src.metrics.em_metrics import (
+    AvgRewardEmbeddingCachedTokensPerCall as AvgRewardEmbeddingCachedTokensPerCall,
+)
+from synalinks.src.metrics.em_metrics import (
     AvgRewardEmbeddingCostPerCall as AvgRewardEmbeddingCostPerCall,
+)
+from synalinks.src.metrics.em_metrics import (
+    AvgRewardEmbeddingLatency as AvgRewardEmbeddingLatency,
 )
 from synalinks.src.metrics.em_metrics import (
     AvgRewardEmbeddingTokensPerCall as AvgRewardEmbeddingTokensPerCall,
@@ -46,6 +62,11 @@ from synalinks.src.metrics.em_metrics import (
     EmbeddingCacheHitRate as EmbeddingCacheHitRate,
 )
 from synalinks.src.metrics.em_metrics import EmbeddingCost as EmbeddingCost
+from synalinks.src.metrics.em_metrics import EmbeddingErrorRate as EmbeddingErrorRate
+from synalinks.src.metrics.em_metrics import EmbeddingFailedCalls as EmbeddingFailedCalls
+from synalinks.src.metrics.em_metrics import (
+    EmbeddingFallbackActivations as EmbeddingFallbackActivations,
+)
 from synalinks.src.metrics.em_metrics import (
     EmbeddingModelOperationalMetric as EmbeddingModelOperationalMetric,
 )
@@ -74,6 +95,15 @@ from synalinks.src.metrics.em_metrics import (
     OptimizerEmbeddingCost as OptimizerEmbeddingCost,
 )
 from synalinks.src.metrics.em_metrics import (
+    OptimizerEmbeddingErrorRate as OptimizerEmbeddingErrorRate,
+)
+from synalinks.src.metrics.em_metrics import (
+    OptimizerEmbeddingFailedCalls as OptimizerEmbeddingFailedCalls,
+)
+from synalinks.src.metrics.em_metrics import (
+    OptimizerEmbeddingFallbackActivations as OptimizerEmbeddingFallbackActivations,
+)
+from synalinks.src.metrics.em_metrics import (
     OptimizerEmbeddingThroughput as OptimizerEmbeddingThroughput,
 )
 from synalinks.src.metrics.em_metrics import (
@@ -95,6 +125,15 @@ from synalinks.src.metrics.em_metrics import (
     RewardEmbeddingCacheHitRate as RewardEmbeddingCacheHitRate,
 )
 from synalinks.src.metrics.em_metrics import RewardEmbeddingCost as RewardEmbeddingCost
+from synalinks.src.metrics.em_metrics import (
+    RewardEmbeddingErrorRate as RewardEmbeddingErrorRate,
+)
+from synalinks.src.metrics.em_metrics import (
+    RewardEmbeddingFailedCalls as RewardEmbeddingFailedCalls,
+)
+from synalinks.src.metrics.em_metrics import (
+    RewardEmbeddingFallbackActivations as RewardEmbeddingFallbackActivations,
+)
 from synalinks.src.metrics.em_metrics import (
     RewardEmbeddingThroughput as RewardEmbeddingThroughput,
 )
@@ -120,9 +159,22 @@ from synalinks.src.metrics.f_score_metrics import (
 from synalinks.src.metrics.f_score_metrics import CategoricalFBetaScore as ListFBetaScore
 from synalinks.src.metrics.f_score_metrics import F1Score as F1Score
 from synalinks.src.metrics.f_score_metrics import FBetaScore as FBetaScore
+from synalinks.src.metrics.lm_metrics import (
+    AvgCacheCreationTokensPerCall as AvgCacheCreationTokensPerCall,
+)
+from synalinks.src.metrics.lm_metrics import (
+    AvgCachedTokensPerCall as AvgCachedTokensPerCall,
+)
 from synalinks.src.metrics.lm_metrics import AvgCostPerCall as AvgCostPerCall
 from synalinks.src.metrics.lm_metrics import (
     AvgInputTokensPerCall as AvgInputTokensPerCall,
+)
+from synalinks.src.metrics.lm_metrics import AvgLatency as AvgLatency
+from synalinks.src.metrics.lm_metrics import (
+    AvgOptimizerCacheCreationTokensPerCall as AvgOptimizerCacheCreationTokensPerCall,
+)
+from synalinks.src.metrics.lm_metrics import (
+    AvgOptimizerCachedTokensPerCall as AvgOptimizerCachedTokensPerCall,
 )
 from synalinks.src.metrics.lm_metrics import (
     AvgOptimizerCostPerCall as AvgOptimizerCostPerCall,
@@ -130,23 +182,52 @@ from synalinks.src.metrics.lm_metrics import (
 from synalinks.src.metrics.lm_metrics import (
     AvgOptimizerInputTokensPerCall as AvgOptimizerInputTokensPerCall,
 )
+from synalinks.src.metrics.lm_metrics import AvgOptimizerLatency as AvgOptimizerLatency
 from synalinks.src.metrics.lm_metrics import (
     AvgOptimizerOutputTokensPerCall as AvgOptimizerOutputTokensPerCall,
 )
 from synalinks.src.metrics.lm_metrics import (
+    AvgOptimizerReasoningTokensPerCall as AvgOptimizerReasoningTokensPerCall,
+)
+from synalinks.src.metrics.lm_metrics import (
+    AvgOptimizerTotalTokensPerCall as AvgOptimizerTotalTokensPerCall,
+)
+from synalinks.src.metrics.lm_metrics import (
     AvgOutputTokensPerCall as AvgOutputTokensPerCall,
+)
+from synalinks.src.metrics.lm_metrics import (
+    AvgReasoningTokensPerCall as AvgReasoningTokensPerCall,
+)
+from synalinks.src.metrics.lm_metrics import (
+    AvgRewardCacheCreationTokensPerCall as AvgRewardCacheCreationTokensPerCall,
+)
+from synalinks.src.metrics.lm_metrics import (
+    AvgRewardCachedTokensPerCall as AvgRewardCachedTokensPerCall,
 )
 from synalinks.src.metrics.lm_metrics import AvgRewardCostPerCall as AvgRewardCostPerCall
 from synalinks.src.metrics.lm_metrics import (
     AvgRewardInputTokensPerCall as AvgRewardInputTokensPerCall,
 )
+from synalinks.src.metrics.lm_metrics import AvgRewardLatency as AvgRewardLatency
 from synalinks.src.metrics.lm_metrics import (
     AvgRewardOutputTokensPerCall as AvgRewardOutputTokensPerCall,
+)
+from synalinks.src.metrics.lm_metrics import (
+    AvgRewardReasoningTokensPerCall as AvgRewardReasoningTokensPerCall,
+)
+from synalinks.src.metrics.lm_metrics import (
+    AvgRewardTotalTokensPerCall as AvgRewardTotalTokensPerCall,
+)
+from synalinks.src.metrics.lm_metrics import (
+    AvgTotalTokensPerCall as AvgTotalTokensPerCall,
 )
 from synalinks.src.metrics.lm_metrics import CacheCreationTokens as CacheCreationTokens
 from synalinks.src.metrics.lm_metrics import CachedTokens as CachedTokens
 from synalinks.src.metrics.lm_metrics import CacheHitRate as CacheHitRate
 from synalinks.src.metrics.lm_metrics import Cost as Cost
+from synalinks.src.metrics.lm_metrics import ErrorRate as ErrorRate
+from synalinks.src.metrics.lm_metrics import FailedCalls as FailedCalls
+from synalinks.src.metrics.lm_metrics import FallbackActivations as FallbackActivations
 from synalinks.src.metrics.lm_metrics import InputTokens as InputTokens
 from synalinks.src.metrics.lm_metrics import LMOperationalMetric as LMOperationalMetric
 from synalinks.src.metrics.lm_metrics import (
@@ -165,6 +246,11 @@ from synalinks.src.metrics.lm_metrics import (
     OptimizerCacheHitRate as OptimizerCacheHitRate,
 )
 from synalinks.src.metrics.lm_metrics import OptimizerCost as OptimizerCost
+from synalinks.src.metrics.lm_metrics import OptimizerErrorRate as OptimizerErrorRate
+from synalinks.src.metrics.lm_metrics import OptimizerFailedCalls as OptimizerFailedCalls
+from synalinks.src.metrics.lm_metrics import (
+    OptimizerFallbackActivations as OptimizerFallbackActivations,
+)
 from synalinks.src.metrics.lm_metrics import OptimizerInputTokens as OptimizerInputTokens
 from synalinks.src.metrics.lm_metrics import (
     OptimizerOutputTokens as OptimizerOutputTokens,
@@ -189,6 +275,11 @@ from synalinks.src.metrics.lm_metrics import (
 from synalinks.src.metrics.lm_metrics import RewardCachedTokens as RewardCachedTokens
 from synalinks.src.metrics.lm_metrics import RewardCacheHitRate as RewardCacheHitRate
 from synalinks.src.metrics.lm_metrics import RewardCost as RewardCost
+from synalinks.src.metrics.lm_metrics import RewardErrorRate as RewardErrorRate
+from synalinks.src.metrics.lm_metrics import RewardFailedCalls as RewardFailedCalls
+from synalinks.src.metrics.lm_metrics import (
+    RewardFallbackActivations as RewardFallbackActivations,
+)
 from synalinks.src.metrics.lm_metrics import RewardInputTokens as RewardInputTokens
 from synalinks.src.metrics.lm_metrics import RewardOutputTokens as RewardOutputTokens
 from synalinks.src.metrics.lm_metrics import (

--- a/synalinks/src/backend/common/op_scope.py
+++ b/synalinks/src/backend/common/op_scope.py
@@ -1,0 +1,109 @@
+# License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
+
+"""Phase scope (`inference` / `reward` / `optimizer`) for operational metrics.
+
+The trainer wraps each phase in ``with op_scope("reward"):`` so the
+LanguageModel / EmbeddingModel can attribute every provider call to the
+phase that triggered it, and so throughput can be measured against the
+phase's true wall-clock span.
+
+Two pieces of state, deliberately kept separate:
+
+- **The active scope** is a ``contextvars.ContextVar``. Synalinks runs LM/EM
+  calls concurrently (``asyncio.gather``) and across greenlets that copy the
+  *context* (see ``utils.async_utils``) — a ``threading.local`` set on the
+  trainer thread would be lost there and calls would be misattributed. A
+  ContextVar is copied into each child task/greenlet at creation, so every
+  concurrent call reads the scope that was active when it was spawned, and
+  sibling phases never clobber each other.
+
+- **Per-phase wall-clock** is accumulated on enter/exit with a nesting stack.
+  Only the scope currently on top of the stack accrues time, so the optimizer
+  phase (which wraps reward computation) is credited its *self* time and does
+  not double-count the nested reward span — mirroring how calls are bucketed.
+  This lives in ``global_state`` (thread-local, reset by ``clear_session``);
+  enter/exit run serially on the trainer's event-loop thread, and that's the
+  same thread that reads the totals when computing metrics.
+"""
+
+import contextvars
+import time
+
+from synalinks.src.backend.common import global_state
+
+PHASES = ("inference", "reward", "optimizer")
+
+_OP_SCOPE = contextvars.ContextVar("synalinks_op_scope", default=None)
+
+_WALL_STATE_KEY = "op_scope_wall_state"
+
+
+def current_op_scope():
+    """Return the active phase (``inference``/``reward``/``optimizer``) or
+    ``None`` when no phase scope is active (e.g. a standalone call)."""
+    scope = _OP_SCOPE.get()
+    return scope if scope in PHASES else None
+
+
+def _wall_state():
+    state = global_state.get_global_attribute(_WALL_STATE_KEY)
+    if state is None:
+        state = {
+            "stack": [],
+            "last_ts": None,
+            "wall": {phase: 0.0 for phase in PHASES},
+        }
+        global_state.set_global_attribute(_WALL_STATE_KEY, state)
+    return state
+
+
+def read_phase_wall_clock_s(phase):
+    """Cumulated wall-clock seconds spent with ``phase`` on top of the scope
+    stack since the last ``clear_session()``."""
+    return _wall_state()["wall"].get(phase, 0.0)
+
+
+def _credit(state, now):
+    """Credit the time since the last transition to the phase currently on
+    top of the stack (its self-time)."""
+    top = state["stack"][-1] if state["stack"] else None
+    if top in state["wall"] and state["last_ts"] is not None:
+        state["wall"][top] += now - state["last_ts"]
+
+
+class op_scope:
+    """Context manager marking a region as running in ``phase``.
+
+    Sets the scope ContextVar for the duration (so concurrent calls spawned
+    inside inherit it) and accrues the region's wall-clock to ``phase``,
+    excluding any nested scopes.
+    """
+
+    def __init__(self, phase):
+        self.phase = phase
+        self._token = None
+
+    def __enter__(self):
+        now = time.perf_counter()
+        state = _wall_state()
+        _credit(state, now)  # close out the parent's running interval first
+        state["stack"].append(self.phase)
+        state["last_ts"] = now
+        self._token = _OP_SCOPE.set(self.phase)
+        return self
+
+    def __exit__(self, *exc_info):
+        now = time.perf_counter()
+        state = _wall_state()
+        _credit(state, now)  # credit this phase's self-time
+        if state["stack"]:
+            state["stack"].pop()
+        state["last_ts"] = now
+        _OP_SCOPE.reset(self._token)
+        return False
+
+
+def _add_phase_wall_clock_s(phase, seconds):
+    """Test helper: add to a phase's wall-clock accumulator without timing a
+    real region."""
+    _wall_state()["wall"][phase] = _wall_state()["wall"].get(phase, 0.0) + seconds

--- a/synalinks/src/metrics/__init__.py
+++ b/synalinks/src/metrics/__init__.py
@@ -4,21 +4,30 @@ from synalinks.src.api_export import synalinks_export
 from synalinks.src.metrics.accuracy_metrics import Accuracy
 from synalinks.src.metrics.accuracy_metrics import BinaryAccuracy
 from synalinks.src.metrics.accuracy_metrics import CategoricalAccuracy
+from synalinks.src.metrics.em_metrics import AvgEmbeddingCachedTokensPerCall
 
 # Note: `accuracy_metrics` is imported below (after `metric`) to avoid a
 # circular import via `synalinks.src.ops -> modules -> module -> metrics`.
 from synalinks.src.metrics.em_metrics import AvgEmbeddingCostPerCall
+from synalinks.src.metrics.em_metrics import AvgEmbeddingLatency
 from synalinks.src.metrics.em_metrics import AvgEmbeddingTokensPerCall
 from synalinks.src.metrics.em_metrics import AvgEmbeddingVectorsPerCall
+from synalinks.src.metrics.em_metrics import AvgOptimizerEmbeddingCachedTokensPerCall
 from synalinks.src.metrics.em_metrics import AvgOptimizerEmbeddingCostPerCall
+from synalinks.src.metrics.em_metrics import AvgOptimizerEmbeddingLatency
 from synalinks.src.metrics.em_metrics import AvgOptimizerEmbeddingTokensPerCall
 from synalinks.src.metrics.em_metrics import AvgOptimizerEmbeddingVectorsPerCall
+from synalinks.src.metrics.em_metrics import AvgRewardEmbeddingCachedTokensPerCall
 from synalinks.src.metrics.em_metrics import AvgRewardEmbeddingCostPerCall
+from synalinks.src.metrics.em_metrics import AvgRewardEmbeddingLatency
 from synalinks.src.metrics.em_metrics import AvgRewardEmbeddingTokensPerCall
 from synalinks.src.metrics.em_metrics import AvgRewardEmbeddingVectorsPerCall
 from synalinks.src.metrics.em_metrics import EmbeddingCachedTokens
 from synalinks.src.metrics.em_metrics import EmbeddingCacheHitRate
 from synalinks.src.metrics.em_metrics import EmbeddingCost
+from synalinks.src.metrics.em_metrics import EmbeddingErrorRate
+from synalinks.src.metrics.em_metrics import EmbeddingFailedCalls
+from synalinks.src.metrics.em_metrics import EmbeddingFallbackActivations
 from synalinks.src.metrics.em_metrics import EmbeddingModelOperationalMetric
 from synalinks.src.metrics.em_metrics import EmbeddingModelOptimizersOperationalMetric
 from synalinks.src.metrics.em_metrics import EmbeddingModelRewardsOperationalMetric
@@ -30,6 +39,9 @@ from synalinks.src.metrics.em_metrics import EmbeddingVectorsPerSecond
 from synalinks.src.metrics.em_metrics import OptimizerEmbeddingCachedTokens
 from synalinks.src.metrics.em_metrics import OptimizerEmbeddingCacheHitRate
 from synalinks.src.metrics.em_metrics import OptimizerEmbeddingCost
+from synalinks.src.metrics.em_metrics import OptimizerEmbeddingErrorRate
+from synalinks.src.metrics.em_metrics import OptimizerEmbeddingFailedCalls
+from synalinks.src.metrics.em_metrics import OptimizerEmbeddingFallbackActivations
 from synalinks.src.metrics.em_metrics import OptimizerEmbeddingThroughput
 from synalinks.src.metrics.em_metrics import OptimizerEmbeddingTokens
 from synalinks.src.metrics.em_metrics import OptimizerEmbeddingTokensPerSecond
@@ -38,6 +50,9 @@ from synalinks.src.metrics.em_metrics import OptimizerEmbeddingVectorsPerSecond
 from synalinks.src.metrics.em_metrics import RewardEmbeddingCachedTokens
 from synalinks.src.metrics.em_metrics import RewardEmbeddingCacheHitRate
 from synalinks.src.metrics.em_metrics import RewardEmbeddingCost
+from synalinks.src.metrics.em_metrics import RewardEmbeddingErrorRate
+from synalinks.src.metrics.em_metrics import RewardEmbeddingFailedCalls
+from synalinks.src.metrics.em_metrics import RewardEmbeddingFallbackActivations
 from synalinks.src.metrics.em_metrics import RewardEmbeddingThroughput
 from synalinks.src.metrics.em_metrics import RewardEmbeddingTokens
 from synalinks.src.metrics.em_metrics import RewardEmbeddingTokensPerSecond
@@ -49,19 +64,37 @@ from synalinks.src.metrics.f_score_metrics import CategoricalF1Score
 from synalinks.src.metrics.f_score_metrics import CategoricalFBetaScore
 from synalinks.src.metrics.f_score_metrics import F1Score
 from synalinks.src.metrics.f_score_metrics import FBetaScore
+from synalinks.src.metrics.lm_metrics import AvgCacheCreationTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgCachedTokensPerCall
 from synalinks.src.metrics.lm_metrics import AvgCostPerCall
 from synalinks.src.metrics.lm_metrics import AvgInputTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgLatency
+from synalinks.src.metrics.lm_metrics import AvgOptimizerCacheCreationTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgOptimizerCachedTokensPerCall
 from synalinks.src.metrics.lm_metrics import AvgOptimizerCostPerCall
 from synalinks.src.metrics.lm_metrics import AvgOptimizerInputTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgOptimizerLatency
 from synalinks.src.metrics.lm_metrics import AvgOptimizerOutputTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgOptimizerReasoningTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgOptimizerTotalTokensPerCall
 from synalinks.src.metrics.lm_metrics import AvgOutputTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgReasoningTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgRewardCacheCreationTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgRewardCachedTokensPerCall
 from synalinks.src.metrics.lm_metrics import AvgRewardCostPerCall
 from synalinks.src.metrics.lm_metrics import AvgRewardInputTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgRewardLatency
 from synalinks.src.metrics.lm_metrics import AvgRewardOutputTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgRewardReasoningTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgRewardTotalTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgTotalTokensPerCall
 from synalinks.src.metrics.lm_metrics import CacheCreationTokens
 from synalinks.src.metrics.lm_metrics import CachedTokens
 from synalinks.src.metrics.lm_metrics import CacheHitRate
 from synalinks.src.metrics.lm_metrics import Cost
+from synalinks.src.metrics.lm_metrics import ErrorRate
+from synalinks.src.metrics.lm_metrics import FailedCalls
+from synalinks.src.metrics.lm_metrics import FallbackActivations
 from synalinks.src.metrics.lm_metrics import InputTokens
 from synalinks.src.metrics.lm_metrics import LMOperationalMetric
 from synalinks.src.metrics.lm_metrics import LMOptimizersOperationalMetric
@@ -70,6 +103,9 @@ from synalinks.src.metrics.lm_metrics import OptimizerCacheCreationTokens
 from synalinks.src.metrics.lm_metrics import OptimizerCachedTokens
 from synalinks.src.metrics.lm_metrics import OptimizerCacheHitRate
 from synalinks.src.metrics.lm_metrics import OptimizerCost
+from synalinks.src.metrics.lm_metrics import OptimizerErrorRate
+from synalinks.src.metrics.lm_metrics import OptimizerFailedCalls
+from synalinks.src.metrics.lm_metrics import OptimizerFallbackActivations
 from synalinks.src.metrics.lm_metrics import OptimizerInputTokens
 from synalinks.src.metrics.lm_metrics import OptimizerOutputTokens
 from synalinks.src.metrics.lm_metrics import OptimizerReasoningTokens
@@ -84,6 +120,9 @@ from synalinks.src.metrics.lm_metrics import RewardCacheCreationTokens
 from synalinks.src.metrics.lm_metrics import RewardCachedTokens
 from synalinks.src.metrics.lm_metrics import RewardCacheHitRate
 from synalinks.src.metrics.lm_metrics import RewardCost
+from synalinks.src.metrics.lm_metrics import RewardErrorRate
+from synalinks.src.metrics.lm_metrics import RewardFailedCalls
+from synalinks.src.metrics.lm_metrics import RewardFallbackActivations
 from synalinks.src.metrics.lm_metrics import RewardInputTokens
 from synalinks.src.metrics.lm_metrics import RewardOutputTokens
 from synalinks.src.metrics.lm_metrics import RewardReasoningTokens
@@ -144,28 +183,41 @@ ALL_OBJECTS = {
     TotalTokens,
     AvgInputTokensPerCall,
     AvgOutputTokensPerCall,
+    AvgTotalTokensPerCall,
     TokensPerSecond,
     Throughput,
+    AvgLatency,
     Cost,
     AvgCostPerCall,
     CachedTokens,
+    AvgCachedTokensPerCall,
     CacheCreationTokens,
+    AvgCacheCreationTokensPerCall,
     CacheHitRate,
     ReasoningTokens,
+    AvgReasoningTokensPerCall,
     ReasoningTokenShare,
+    FailedCalls,
+    FallbackActivations,
+    ErrorRate,
     # Operational (embedding model)
     EmbeddingModelOperationalMetric,
     EmbeddingTokens,
     EmbeddingVectors,
     EmbeddingCost,
     EmbeddingThroughput,
+    AvgEmbeddingLatency,
     EmbeddingTokensPerSecond,
     EmbeddingVectorsPerSecond,
     AvgEmbeddingTokensPerCall,
     AvgEmbeddingVectorsPerCall,
     AvgEmbeddingCostPerCall,
     EmbeddingCachedTokens,
+    AvgEmbeddingCachedTokensPerCall,
     EmbeddingCacheHitRate,
+    EmbeddingFailedCalls,
+    EmbeddingFallbackActivations,
+    EmbeddingErrorRate,
     # Operational (language model, reward phase)
     LMRewardsOperationalMetric,
     RewardInputTokens,
@@ -173,15 +225,23 @@ ALL_OBJECTS = {
     RewardTotalTokens,
     AvgRewardInputTokensPerCall,
     AvgRewardOutputTokensPerCall,
+    AvgRewardTotalTokensPerCall,
     RewardTokensPerSecond,
     RewardThroughput,
+    AvgRewardLatency,
     RewardCost,
     AvgRewardCostPerCall,
     RewardCachedTokens,
+    AvgRewardCachedTokensPerCall,
     RewardCacheCreationTokens,
+    AvgRewardCacheCreationTokensPerCall,
     RewardCacheHitRate,
     RewardReasoningTokens,
+    AvgRewardReasoningTokensPerCall,
     RewardReasoningTokenShare,
+    RewardFailedCalls,
+    RewardFallbackActivations,
+    RewardErrorRate,
     # Operational (language model, optimizer phase)
     LMOptimizersOperationalMetric,
     OptimizerInputTokens,
@@ -189,41 +249,59 @@ ALL_OBJECTS = {
     OptimizerTotalTokens,
     AvgOptimizerInputTokensPerCall,
     AvgOptimizerOutputTokensPerCall,
+    AvgOptimizerTotalTokensPerCall,
     OptimizerTokensPerSecond,
     OptimizerThroughput,
+    AvgOptimizerLatency,
     OptimizerCost,
     AvgOptimizerCostPerCall,
     OptimizerCachedTokens,
+    AvgOptimizerCachedTokensPerCall,
     OptimizerCacheCreationTokens,
+    AvgOptimizerCacheCreationTokensPerCall,
     OptimizerCacheHitRate,
     OptimizerReasoningTokens,
+    AvgOptimizerReasoningTokensPerCall,
     OptimizerReasoningTokenShare,
+    OptimizerFailedCalls,
+    OptimizerFallbackActivations,
+    OptimizerErrorRate,
     # Operational (embedding model, reward phase)
     EmbeddingModelRewardsOperationalMetric,
     RewardEmbeddingTokens,
     RewardEmbeddingVectors,
     RewardEmbeddingCost,
     RewardEmbeddingThroughput,
+    AvgRewardEmbeddingLatency,
     RewardEmbeddingTokensPerSecond,
     RewardEmbeddingVectorsPerSecond,
     AvgRewardEmbeddingTokensPerCall,
     AvgRewardEmbeddingVectorsPerCall,
     AvgRewardEmbeddingCostPerCall,
     RewardEmbeddingCachedTokens,
+    AvgRewardEmbeddingCachedTokensPerCall,
     RewardEmbeddingCacheHitRate,
+    RewardEmbeddingFailedCalls,
+    RewardEmbeddingFallbackActivations,
+    RewardEmbeddingErrorRate,
     # Operational (embedding model, optimizer phase)
     EmbeddingModelOptimizersOperationalMetric,
     OptimizerEmbeddingTokens,
     OptimizerEmbeddingVectors,
     OptimizerEmbeddingCost,
     OptimizerEmbeddingThroughput,
+    AvgOptimizerEmbeddingLatency,
     OptimizerEmbeddingTokensPerSecond,
     OptimizerEmbeddingVectorsPerSecond,
     AvgOptimizerEmbeddingTokensPerCall,
     AvgOptimizerEmbeddingVectorsPerCall,
     AvgOptimizerEmbeddingCostPerCall,
     OptimizerEmbeddingCachedTokens,
+    AvgOptimizerEmbeddingCachedTokensPerCall,
     OptimizerEmbeddingCacheHitRate,
+    OptimizerEmbeddingFailedCalls,
+    OptimizerEmbeddingFallbackActivations,
+    OptimizerEmbeddingErrorRate,
     # Operational (program-wide)
     ProgramOperationalMetric,
     ProgramCalls,

--- a/synalinks/src/metrics/em_metrics.py
+++ b/synalinks/src/metrics/em_metrics.py
@@ -4,7 +4,7 @@
 
 All metrics read counters that the EM populates on each provider call.
 Routing across `inference`, `reward`, and `optimizer` phases follows the
-`synalinks_op_scope` global flag set by the trainer.
+active `op_scope` (a contextvar the trainer sets per phase).
 
 Class hierarchy:
 
@@ -14,6 +14,7 @@ Class hierarchy:
 """
 
 from synalinks.src.api_export import synalinks_export
+from synalinks.src.backend.common.op_scope import read_phase_wall_clock_s
 from synalinks.src.metrics.metric import Metric
 
 _TRACKED_SUFFIXES = (
@@ -24,6 +25,8 @@ _TRACKED_SUFFIXES = (
     "elapsed_s",
     "cost",
     "cached_tokens",
+    "failed_calls",
+    "fallback_activations",
 )
 
 
@@ -71,8 +74,8 @@ class EmbeddingModelOperationalMetric(Metric):
 
     Subclasses set `_phase` to one of ``"inference"``, ``"reward"``, or
     ``"optimizer"`` to read the corresponding counter set on each bound
-    embedding model. Counters are populated by the EM based on the
-    ``synalinks_op_scope`` global flag set by the trainer.
+    embedding model. Counters are populated by the EM based on the active
+    ``op_scope`` (contextvar) the trainer sets for each phase.
 
     Binds itself automatically to every `EmbeddingModel` reachable from
     the program (and their `.fallback` chains) on `program.compile()`.
@@ -84,6 +87,7 @@ class EmbeddingModelOperationalMetric(Metric):
         super().__init__(name=name)
         self._embedding_models = []
         self._baselines = {suffix: 0 for suffix in _TRACKED_SUFFIXES}
+        self._wall_baseline = 0.0
 
     @property
     def embedding_models(self):
@@ -103,9 +107,17 @@ class EmbeddingModelOperationalMetric(Metric):
     def _snapshot(self):
         for suffix in _TRACKED_SUFFIXES:
             self._baselines[suffix] = self._read(suffix)
+        self._wall_baseline = read_phase_wall_clock_s(self._phase)
 
     def _delta(self, suffix):
         return self._read(suffix) - self._baselines.get(suffix, 0)
+
+    def _wall_clock_delta(self):
+        """Wall-clock seconds the trainer spent in this metric's phase since
+        the last snapshot — the throughput denominator (concurrency-safe,
+        unlike summed `elapsed_s`).
+        """
+        return read_phase_wall_clock_s(self._phase) - self._wall_baseline
 
     def reset_state(self):
         self._snapshot()
@@ -161,10 +173,31 @@ class EmbeddingThroughput(EmbeddingModelOperationalMetric):
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("calls") / elapsed
+        return self._delta("calls") / wall
+
+
+@synalinks_export("synalinks.metrics.AvgEmbeddingLatency")
+class AvgEmbeddingLatency(EmbeddingModelOperationalMetric):
+    """Average wall-clock latency in seconds per embedding call over this run.
+
+    Computed as ``elapsed_s / calls``. Because ``elapsed_s`` accumulates each
+    call's own duration, this reports the mean per-call latency regardless of
+    concurrency -- unlike `EmbeddingThroughput`, which divides by the phase's
+    wall-clock span. The two coincide (latency = 1 / throughput) only when
+    calls run serially.
+    """
+
+    def __init__(self, name="avg_embedding_latency"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("elapsed_s") / calls
 
 
 @synalinks_export("synalinks.metrics.EmbeddingTokensPerSecond")
@@ -175,10 +208,10 @@ class EmbeddingTokensPerSecond(EmbeddingModelOperationalMetric):
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("tokens") / elapsed
+        return self._delta("tokens") / wall
 
 
 @synalinks_export("synalinks.metrics.EmbeddingVectorsPerSecond")
@@ -189,10 +222,10 @@ class EmbeddingVectorsPerSecond(EmbeddingModelOperationalMetric):
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("vectors") / elapsed
+        return self._delta("vectors") / wall
 
 
 @synalinks_export("synalinks.metrics.AvgEmbeddingTokensPerCall")
@@ -237,6 +270,20 @@ class AvgEmbeddingCostPerCall(EmbeddingModelOperationalMetric):
         return self._delta("cost") / calls
 
 
+@synalinks_export("synalinks.metrics.AvgEmbeddingCachedTokensPerCall")
+class AvgEmbeddingCachedTokensPerCall(EmbeddingModelOperationalMetric):
+    """Average cached prompt tokens per embedding call over this run."""
+
+    def __init__(self, name="avg_embedding_cached_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("cached_tokens") / calls
+
+
 @synalinks_export("synalinks.metrics.EmbeddingCachedTokens")
 class EmbeddingCachedTokens(EmbeddingModelOperationalMetric):
     """Prompt tokens served from cache during embedding inference."""
@@ -260,6 +307,43 @@ class EmbeddingCacheHitRate(EmbeddingModelOperationalMetric):
         if prompt <= 0:
             return 0.0
         return self._delta("cached_tokens") / prompt
+
+
+@synalinks_export("synalinks.metrics.EmbeddingFailedCalls")
+class EmbeddingFailedCalls(EmbeddingModelOperationalMetric):
+    """Embedding calls that exhausted all retries and failed this run."""
+
+    def __init__(self, name="embedding_failed_calls"):
+        super().__init__(name=name)
+
+    def result(self):
+        return int(self._delta("failed_calls"))
+
+
+@synalinks_export("synalinks.metrics.EmbeddingFallbackActivations")
+class EmbeddingFallbackActivations(EmbeddingModelOperationalMetric):
+    """Times a failed embedding call triggered its `fallback` chain."""
+
+    def __init__(self, name="embedding_fallback_activations"):
+        super().__init__(name=name)
+
+    def result(self):
+        return int(self._delta("fallback_activations"))
+
+
+@synalinks_export("synalinks.metrics.EmbeddingErrorRate")
+class EmbeddingErrorRate(EmbeddingModelOperationalMetric):
+    """Fraction of embedding calls that failed: failed / (succeeded + failed)."""
+
+    def __init__(self, name="embedding_error_rate"):
+        super().__init__(name=name)
+
+    def result(self):
+        failed = self._delta("failed_calls")
+        total = self._delta("calls") + failed
+        if total <= 0:
+            return 0.0
+        return failed / total
 
 
 # ---------------------------------------------------------------------------
@@ -320,10 +404,24 @@ class RewardEmbeddingThroughput(EmbeddingModelRewardsOperationalMetric):
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("calls") / elapsed
+        return self._delta("calls") / wall
+
+
+@synalinks_export("synalinks.metrics.AvgRewardEmbeddingLatency")
+class AvgRewardEmbeddingLatency(EmbeddingModelRewardsOperationalMetric):
+    """Average latency (s) per embedding call during reward computation."""
+
+    def __init__(self, name="avg_reward_embedding_latency"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("elapsed_s") / calls
 
 
 @synalinks_export("synalinks.metrics.RewardEmbeddingTokensPerSecond")
@@ -334,10 +432,10 @@ class RewardEmbeddingTokensPerSecond(EmbeddingModelRewardsOperationalMetric):
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("tokens") / elapsed
+        return self._delta("tokens") / wall
 
 
 @synalinks_export("synalinks.metrics.RewardEmbeddingVectorsPerSecond")
@@ -348,10 +446,10 @@ class RewardEmbeddingVectorsPerSecond(EmbeddingModelRewardsOperationalMetric):
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("vectors") / elapsed
+        return self._delta("vectors") / wall
 
 
 @synalinks_export("synalinks.metrics.AvgRewardEmbeddingTokensPerCall")
@@ -396,6 +494,20 @@ class AvgRewardEmbeddingCostPerCall(EmbeddingModelRewardsOperationalMetric):
         return self._delta("cost") / calls
 
 
+@synalinks_export("synalinks.metrics.AvgRewardEmbeddingCachedTokensPerCall")
+class AvgRewardEmbeddingCachedTokensPerCall(EmbeddingModelRewardsOperationalMetric):
+    """Average cached prompt tokens per embedding call during reward computation."""
+
+    def __init__(self, name="avg_reward_embedding_cached_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("cached_tokens") / calls
+
+
 @synalinks_export("synalinks.metrics.RewardEmbeddingCachedTokens")
 class RewardEmbeddingCachedTokens(EmbeddingModelRewardsOperationalMetric):
     """Prompt tokens served from cache during reward-phase embeddings."""
@@ -419,6 +531,43 @@ class RewardEmbeddingCacheHitRate(EmbeddingModelRewardsOperationalMetric):
         if prompt <= 0:
             return 0.0
         return self._delta("cached_tokens") / prompt
+
+
+@synalinks_export("synalinks.metrics.RewardEmbeddingFailedCalls")
+class RewardEmbeddingFailedCalls(EmbeddingModelRewardsOperationalMetric):
+    """Embedding calls that failed during reward computation."""
+
+    def __init__(self, name="reward_embedding_failed_calls"):
+        super().__init__(name=name)
+
+    def result(self):
+        return int(self._delta("failed_calls"))
+
+
+@synalinks_export("synalinks.metrics.RewardEmbeddingFallbackActivations")
+class RewardEmbeddingFallbackActivations(EmbeddingModelRewardsOperationalMetric):
+    """Embedding fallback activations during reward computation."""
+
+    def __init__(self, name="reward_embedding_fallback_activations"):
+        super().__init__(name=name)
+
+    def result(self):
+        return int(self._delta("fallback_activations"))
+
+
+@synalinks_export("synalinks.metrics.RewardEmbeddingErrorRate")
+class RewardEmbeddingErrorRate(EmbeddingModelRewardsOperationalMetric):
+    """Fraction of embedding calls that failed during reward computation."""
+
+    def __init__(self, name="reward_embedding_error_rate"):
+        super().__init__(name=name)
+
+    def result(self):
+        failed = self._delta("failed_calls")
+        total = self._delta("calls") + failed
+        if total <= 0:
+            return 0.0
+        return failed / total
 
 
 # ---------------------------------------------------------------------------
@@ -479,10 +628,24 @@ class OptimizerEmbeddingThroughput(EmbeddingModelOptimizersOperationalMetric):
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("calls") / elapsed
+        return self._delta("calls") / wall
+
+
+@synalinks_export("synalinks.metrics.AvgOptimizerEmbeddingLatency")
+class AvgOptimizerEmbeddingLatency(EmbeddingModelOptimizersOperationalMetric):
+    """Average latency (s) per embedding call during the optimizer step."""
+
+    def __init__(self, name="avg_optimizer_embedding_latency"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("elapsed_s") / calls
 
 
 @synalinks_export("synalinks.metrics.OptimizerEmbeddingTokensPerSecond")
@@ -493,10 +656,10 @@ class OptimizerEmbeddingTokensPerSecond(EmbeddingModelOptimizersOperationalMetri
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("tokens") / elapsed
+        return self._delta("tokens") / wall
 
 
 @synalinks_export("synalinks.metrics.OptimizerEmbeddingVectorsPerSecond")
@@ -507,10 +670,10 @@ class OptimizerEmbeddingVectorsPerSecond(EmbeddingModelOptimizersOperationalMetr
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("vectors") / elapsed
+        return self._delta("vectors") / wall
 
 
 @synalinks_export("synalinks.metrics.AvgOptimizerEmbeddingTokensPerCall")
@@ -555,6 +718,20 @@ class AvgOptimizerEmbeddingCostPerCall(EmbeddingModelOptimizersOperationalMetric
         return self._delta("cost") / calls
 
 
+@synalinks_export("synalinks.metrics.AvgOptimizerEmbeddingCachedTokensPerCall")
+class AvgOptimizerEmbeddingCachedTokensPerCall(EmbeddingModelOptimizersOperationalMetric):
+    """Average cached prompt tokens per embedding call during the optimizer step."""
+
+    def __init__(self, name="avg_optimizer_embedding_cached_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("cached_tokens") / calls
+
+
 @synalinks_export("synalinks.metrics.OptimizerEmbeddingCachedTokens")
 class OptimizerEmbeddingCachedTokens(EmbeddingModelOptimizersOperationalMetric):
     """Prompt tokens served from cache during optimizer-phase embeddings."""
@@ -578,3 +755,40 @@ class OptimizerEmbeddingCacheHitRate(EmbeddingModelOptimizersOperationalMetric):
         if prompt <= 0:
             return 0.0
         return self._delta("cached_tokens") / prompt
+
+
+@synalinks_export("synalinks.metrics.OptimizerEmbeddingFailedCalls")
+class OptimizerEmbeddingFailedCalls(EmbeddingModelOptimizersOperationalMetric):
+    """Embedding calls that failed during the optimizer step."""
+
+    def __init__(self, name="optimizer_embedding_failed_calls"):
+        super().__init__(name=name)
+
+    def result(self):
+        return int(self._delta("failed_calls"))
+
+
+@synalinks_export("synalinks.metrics.OptimizerEmbeddingFallbackActivations")
+class OptimizerEmbeddingFallbackActivations(EmbeddingModelOptimizersOperationalMetric):
+    """Embedding fallback activations during the optimizer step."""
+
+    def __init__(self, name="optimizer_embedding_fallback_activations"):
+        super().__init__(name=name)
+
+    def result(self):
+        return int(self._delta("fallback_activations"))
+
+
+@synalinks_export("synalinks.metrics.OptimizerEmbeddingErrorRate")
+class OptimizerEmbeddingErrorRate(EmbeddingModelOptimizersOperationalMetric):
+    """Fraction of embedding calls that failed during the optimizer step."""
+
+    def __init__(self, name="optimizer_embedding_error_rate"):
+        super().__init__(name=name)
+
+    def result(self):
+        failed = self._delta("failed_calls")
+        total = self._delta("calls") + failed
+        if total <= 0:
+            return 0.0
+        return failed / total

--- a/synalinks/src/metrics/em_metrics_test.py
+++ b/synalinks/src/metrics/em_metrics_test.py
@@ -1,18 +1,28 @@
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
 from synalinks.src import testing
+from synalinks.src.backend.common.op_scope import _add_phase_wall_clock_s
+from synalinks.src.metrics.em_metrics import AvgEmbeddingCachedTokensPerCall
 from synalinks.src.metrics.em_metrics import AvgEmbeddingCostPerCall
+from synalinks.src.metrics.em_metrics import AvgEmbeddingLatency
 from synalinks.src.metrics.em_metrics import AvgEmbeddingTokensPerCall
 from synalinks.src.metrics.em_metrics import AvgEmbeddingVectorsPerCall
+from synalinks.src.metrics.em_metrics import AvgOptimizerEmbeddingCachedTokensPerCall
 from synalinks.src.metrics.em_metrics import AvgOptimizerEmbeddingCostPerCall
+from synalinks.src.metrics.em_metrics import AvgOptimizerEmbeddingLatency
 from synalinks.src.metrics.em_metrics import AvgOptimizerEmbeddingTokensPerCall
 from synalinks.src.metrics.em_metrics import AvgOptimizerEmbeddingVectorsPerCall
+from synalinks.src.metrics.em_metrics import AvgRewardEmbeddingCachedTokensPerCall
 from synalinks.src.metrics.em_metrics import AvgRewardEmbeddingCostPerCall
+from synalinks.src.metrics.em_metrics import AvgRewardEmbeddingLatency
 from synalinks.src.metrics.em_metrics import AvgRewardEmbeddingTokensPerCall
 from synalinks.src.metrics.em_metrics import AvgRewardEmbeddingVectorsPerCall
 from synalinks.src.metrics.em_metrics import EmbeddingCachedTokens
 from synalinks.src.metrics.em_metrics import EmbeddingCacheHitRate
 from synalinks.src.metrics.em_metrics import EmbeddingCost
+from synalinks.src.metrics.em_metrics import EmbeddingErrorRate
+from synalinks.src.metrics.em_metrics import EmbeddingFailedCalls
+from synalinks.src.metrics.em_metrics import EmbeddingFallbackActivations
 from synalinks.src.metrics.em_metrics import EmbeddingThroughput
 from synalinks.src.metrics.em_metrics import EmbeddingTokens
 from synalinks.src.metrics.em_metrics import EmbeddingTokensPerSecond
@@ -21,6 +31,9 @@ from synalinks.src.metrics.em_metrics import EmbeddingVectorsPerSecond
 from synalinks.src.metrics.em_metrics import OptimizerEmbeddingCachedTokens
 from synalinks.src.metrics.em_metrics import OptimizerEmbeddingCacheHitRate
 from synalinks.src.metrics.em_metrics import OptimizerEmbeddingCost
+from synalinks.src.metrics.em_metrics import OptimizerEmbeddingErrorRate
+from synalinks.src.metrics.em_metrics import OptimizerEmbeddingFailedCalls
+from synalinks.src.metrics.em_metrics import OptimizerEmbeddingFallbackActivations
 from synalinks.src.metrics.em_metrics import OptimizerEmbeddingThroughput
 from synalinks.src.metrics.em_metrics import OptimizerEmbeddingTokens
 from synalinks.src.metrics.em_metrics import OptimizerEmbeddingTokensPerSecond
@@ -29,6 +42,9 @@ from synalinks.src.metrics.em_metrics import OptimizerEmbeddingVectorsPerSecond
 from synalinks.src.metrics.em_metrics import RewardEmbeddingCachedTokens
 from synalinks.src.metrics.em_metrics import RewardEmbeddingCacheHitRate
 from synalinks.src.metrics.em_metrics import RewardEmbeddingCost
+from synalinks.src.metrics.em_metrics import RewardEmbeddingErrorRate
+from synalinks.src.metrics.em_metrics import RewardEmbeddingFailedCalls
+from synalinks.src.metrics.em_metrics import RewardEmbeddingFallbackActivations
 from synalinks.src.metrics.em_metrics import RewardEmbeddingThroughput
 from synalinks.src.metrics.em_metrics import RewardEmbeddingTokens
 from synalinks.src.metrics.em_metrics import RewardEmbeddingTokensPerSecond
@@ -118,14 +134,35 @@ class EmbeddingMetricsResultTest(testing.TestCase):
     def test_throughput(self):
         em = _stub_em()
         m_rps = _bind(EmbeddingThroughput(), [em])
+        # Throughput divides by phase wall-clock, not summed call time.
+        _add_phase_wall_clock_s("inference", 4.0)
         _record(em, prompt=100, vectors=2, elapsed=2.0, cost=0.0)
         _record(em, prompt=100, vectors=2, elapsed=2.0, cost=0.0)
         self.assertEqual(m_rps.result(), 2 / 4.0)
 
+    def test_avg_latency(self):
+        em = _stub_em()
+        m_lat = _bind(AvgEmbeddingLatency(), [em])
+        _record(em, prompt=100, vectors=2, elapsed=2.0, cost=0.0)
+        _record(em, prompt=100, vectors=2, elapsed=3.0, cost=0.0)
+        # Mean per-call latency = summed call time / calls = 5.0 / 2
+        # (unchanged by the wall-clock throughput switch).
+        self.assertEqual(m_lat.result(), 5.0 / 2)
+
+    def test_cached_tokens_average(self):
+        em = _stub_em()
+        m = _bind(AvgEmbeddingCachedTokensPerCall(), [em])
+        _record(em, prompt=100, vectors=2, elapsed=0.1, cost=0.0)
+        _record(em, prompt=100, vectors=2, elapsed=0.1, cost=0.0)
+        _bump_cached(em, 60, phase="inference")
+        self.assertEqual(m.result(), 30.0)  # 60 / 2
+
     def test_zero_division_safety(self):
         em = _stub_em()
         m = _bind(AvgEmbeddingTokensPerCall(), [em])
+        m_lat = _bind(AvgEmbeddingLatency(), [em])
         self.assertEqual(m.result(), 0.0)
+        self.assertEqual(m_lat.result(), 0.0)
 
 
 class EMAutoBindTest(testing.TestCase):
@@ -214,6 +251,58 @@ def _bump_cached(em, n, phase):
     setattr(em, attr, getattr(em, attr, 0) + n)
 
 
+def _bump(em, suffix, n, phase):
+    attr = f"{phase}_cumulated_{suffix}"
+    setattr(em, attr, getattr(em, attr, 0) + n)
+
+
+class EmbeddingFailureMetricsTest(testing.TestCase):
+    def test_failure_metrics(self):
+        em = _stub_em()
+        m_failed = _bind(EmbeddingFailedCalls(), [em])
+        m_fallback = _bind(EmbeddingFallbackActivations(), [em])
+        m_error = _bind(EmbeddingErrorRate(), [em])
+        # 3 successful calls; 1 failed call that fell back.
+        _record(em, prompt=10, vectors=1, phase="inference")
+        _record(em, prompt=10, vectors=1, phase="inference")
+        _record(em, prompt=10, vectors=1, phase="inference")
+        _bump(em, "failed_calls", 1, phase="inference")
+        _bump(em, "fallback_activations", 1, phase="inference")
+        self.assertEqual(m_failed.result(), 1)
+        self.assertEqual(m_fallback.result(), 1)
+        self.assertEqual(m_error.result(), 1 / 4)
+
+    def test_failure_metrics_per_phase(self):
+        for phase, FailedM, FallbackM, ErrorM in (
+            (
+                "reward",
+                RewardEmbeddingFailedCalls,
+                RewardEmbeddingFallbackActivations,
+                RewardEmbeddingErrorRate,
+            ),
+            (
+                "optimizer",
+                OptimizerEmbeddingFailedCalls,
+                OptimizerEmbeddingFallbackActivations,
+                OptimizerEmbeddingErrorRate,
+            ),
+        ):
+            with self.subTest(phase=phase):
+                em = _stub_em()
+                m_failed = _bind(FailedM(), [em])
+                m_fallback = _bind(FallbackM(), [em])
+                m_error = _bind(ErrorM(), [em])
+                self.assertEqual(m_failed.result(), 0)
+                self.assertEqual(m_fallback.result(), 0)
+                self.assertEqual(m_error.result(), 0.0)
+                _record(em, prompt=10, vectors=1, phase=phase)
+                _bump(em, "failed_calls", 3, phase=phase)
+                _bump(em, "fallback_activations", 2, phase=phase)
+                self.assertEqual(m_failed.result(), 3)
+                self.assertEqual(m_fallback.result(), 2)
+                self.assertEqual(m_error.result(), 3 / 4)
+
+
 class EMRatesAndCacheTest(testing.TestCase):
     """`result()` paths for rate, per-call, and cache-hit-rate metrics that
     the existing tests don't hit. Three phases (inference/reward/optimizer)
@@ -262,6 +351,7 @@ class EMRatesAndCacheTest(testing.TestCase):
 
                 _record(em, prompt=200, vectors=8, elapsed=4.0, phase=phase)
                 _bump_cached(em, 50, phase=phase)
+                _add_phase_wall_clock_s(phase, 4.0)  # throughput denominator
 
                 self.assertEqual(m_tps.result(), 50.0)  # 200 / 4.0
                 self.assertEqual(m_vps.result(), 2.0)  # 8 / 4.0
@@ -281,7 +371,23 @@ class EMRatesAndCacheTest(testing.TestCase):
                 self.assertEqual(m.result(), 0.0)
                 _record(em, prompt=10, vectors=1, elapsed=2.0, phase=phase)
                 _record(em, prompt=10, vectors=1, elapsed=2.0, phase=phase)
+                _add_phase_wall_clock_s(phase, 4.0)
                 self.assertEqual(m.result(), 2 / 4.0)
+
+    def test_avg_latency_per_phase(self):
+        # Inference latency has a dedicated test above; cover the reward +
+        # optimizer variants (elapsed_s_delta / calls_delta).
+        for phase, Latency in (
+            ("reward", AvgRewardEmbeddingLatency),
+            ("optimizer", AvgOptimizerEmbeddingLatency),
+        ):
+            with self.subTest(phase=phase):
+                em = _stub_em()
+                m = _bind(Latency(), [em])
+                self.assertEqual(m.result(), 0.0)
+                _record(em, prompt=10, vectors=1, elapsed=2.0, phase=phase)
+                _record(em, prompt=10, vectors=1, elapsed=2.0, phase=phase)
+                self.assertEqual(m.result(), 4.0 / 2)
 
     def test_avg_per_call_metrics_per_phase(self):
         # `AvgRewardEmbeddingTokensPerCall`, `AvgRewardEmbeddingVectorsPerCall`,
@@ -316,3 +422,19 @@ class EMRatesAndCacheTest(testing.TestCase):
                 self.assertEqual(m_t.result(), 200.0)
                 self.assertEqual(m_v.result(), 4.0)
                 self.assertAlmostEqual(m_c.result(), 0.002)
+
+    def test_cached_average_per_phase(self):
+        # Inference variant has a dedicated test above; cover reward +
+        # optimizer for `Avg*EmbeddingCachedTokensPerCall`.
+        for phase, AvgCached in (
+            ("reward", AvgRewardEmbeddingCachedTokensPerCall),
+            ("optimizer", AvgOptimizerEmbeddingCachedTokensPerCall),
+        ):
+            with self.subTest(phase=phase):
+                em = _stub_em()
+                m_cached = _bind(AvgCached(), [em])
+                self.assertEqual(m_cached.result(), 0.0)
+                _record(em, prompt=100, vectors=2, phase=phase)
+                _record(em, prompt=100, vectors=2, phase=phase)
+                _bump_cached(em, 60, phase=phase)
+                self.assertEqual(m_cached.result(), 30.0)  # 60 / 2

--- a/synalinks/src/metrics/lm_metrics.py
+++ b/synalinks/src/metrics/lm_metrics.py
@@ -4,7 +4,8 @@
 
 All metrics in this file read counters that the LM populates on each
 provider call. Routing across `inference`, `reward`, and `optimizer`
-phases follows the `synalinks_op_scope` global flag set by the trainer.
+phases follows the active `op_scope` (a contextvar the trainer sets via
+`synalinks.src.backend.common.op_scope.op_scope`).
 
 Class hierarchy:
 
@@ -14,6 +15,7 @@ Class hierarchy:
 """
 
 from synalinks.src.api_export import synalinks_export
+from synalinks.src.backend.common.op_scope import read_phase_wall_clock_s
 from synalinks.src.metrics.metric import Metric
 
 _TRACKED_SUFFIXES = (
@@ -26,6 +28,8 @@ _TRACKED_SUFFIXES = (
     "cached_tokens",
     "cache_creation_tokens",
     "reasoning_tokens",
+    "failed_calls",
+    "fallback_activations",
 )
 
 
@@ -73,8 +77,8 @@ class LMOperationalMetric(Metric):
 
     Subclasses set `_phase` to one of ``"inference"``, ``"reward"``, or
     ``"optimizer"`` to read from the corresponding counter set on each
-    bound LM. Counters are populated by the LM based on the
-    ``synalinks_op_scope`` global flag set by the trainer.
+    bound LM. Counters are populated by the LM based on the active
+    ``op_scope`` (contextvar) the trainer sets for each phase.
 
     The metric binds itself automatically to every `LanguageModel`
     reachable from the program (and their `.fallback` chains) when
@@ -87,6 +91,7 @@ class LMOperationalMetric(Metric):
         super().__init__(name=name)
         self._language_models = []
         self._baselines = {suffix: 0 for suffix in _TRACKED_SUFFIXES}
+        self._wall_baseline = 0.0
 
     @property
     def language_models(self):
@@ -106,9 +111,17 @@ class LMOperationalMetric(Metric):
     def _snapshot(self):
         for suffix in _TRACKED_SUFFIXES:
             self._baselines[suffix] = self._read(suffix)
+        self._wall_baseline = read_phase_wall_clock_s(self._phase)
 
     def _delta(self, suffix):
         return self._read(suffix) - self._baselines.get(suffix, 0)
+
+    def _wall_clock_delta(self):
+        """Wall-clock seconds the trainer spent in this metric's phase since
+        the last snapshot. Used as the throughput denominator so concurrent
+        (overlapping) calls don't inflate it the way summed `elapsed_s` does.
+        """
+        return read_phase_wall_clock_s(self._phase) - self._wall_baseline
 
     def reset_state(self):
         self._snapshot()
@@ -184,6 +197,62 @@ class AvgOutputTokensPerCall(LMOperationalMetric):
         return self._delta("completion_tokens") / calls
 
 
+@synalinks_export("synalinks.metrics.AvgTotalTokensPerCall")
+class AvgTotalTokensPerCall(LMOperationalMetric):
+    """Average total tokens (input + output) per LM call over this run."""
+
+    def __init__(self, name="avg_total_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("tokens") / calls
+
+
+@synalinks_export("synalinks.metrics.AvgCachedTokensPerCall")
+class AvgCachedTokensPerCall(LMOperationalMetric):
+    """Average cached prompt tokens per LM call over this run."""
+
+    def __init__(self, name="avg_cached_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("cached_tokens") / calls
+
+
+@synalinks_export("synalinks.metrics.AvgCacheCreationTokensPerCall")
+class AvgCacheCreationTokensPerCall(LMOperationalMetric):
+    """Average cache-creation tokens per LM call over this run."""
+
+    def __init__(self, name="avg_cache_creation_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("cache_creation_tokens") / calls
+
+
+@synalinks_export("synalinks.metrics.AvgReasoningTokensPerCall")
+class AvgReasoningTokensPerCall(LMOperationalMetric):
+    """Average reasoning/thinking tokens per LM call over this run."""
+
+    def __init__(self, name="avg_reasoning_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("reasoning_tokens") / calls
+
+
 @synalinks_export("synalinks.metrics.TokensPerSecond")
 class TokensPerSecond(LMOperationalMetric):
     """Throughput in total tokens per second over this run."""
@@ -192,10 +261,10 @@ class TokensPerSecond(LMOperationalMetric):
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("tokens") / elapsed
+        return self._delta("tokens") / wall
 
 
 @synalinks_export("synalinks.metrics.Throughput")
@@ -206,10 +275,31 @@ class Throughput(LMOperationalMetric):
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("calls") / elapsed
+        return self._delta("calls") / wall
+
+
+@synalinks_export("synalinks.metrics.AvgLatency")
+class AvgLatency(LMOperationalMetric):
+    """Average wall-clock latency in seconds per LM call over this run.
+
+    Computed as ``elapsed_s / calls``. Because ``elapsed_s`` accumulates each
+    call's own duration, this reports the mean per-call latency regardless of
+    how many calls ran concurrently -- unlike `Throughput`, which divides by
+    the phase's wall-clock span and so does reflect concurrency. The two
+    coincide (latency = 1 / throughput) only when calls run serially.
+    """
+
+    def __init__(self, name="avg_latency"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("elapsed_s") / calls
 
 
 @synalinks_export("synalinks.metrics.Cost")
@@ -315,6 +405,48 @@ class ReasoningTokenShare(LMOperationalMetric):
         return self._delta("reasoning_tokens") / completion
 
 
+@synalinks_export("synalinks.metrics.FailedCalls")
+class FailedCalls(LMOperationalMetric):
+    """LM calls that exhausted all retries and ultimately failed this run."""
+
+    def __init__(self, name="failed_calls"):
+        super().__init__(name=name)
+
+    def result(self):
+        return int(self._delta("failed_calls"))
+
+
+@synalinks_export("synalinks.metrics.FallbackActivations")
+class FallbackActivations(LMOperationalMetric):
+    """Times a failed LM call triggered its `fallback` chain this run."""
+
+    def __init__(self, name="fallback_activations"):
+        super().__init__(name=name)
+
+    def result(self):
+        return int(self._delta("fallback_activations"))
+
+
+@synalinks_export("synalinks.metrics.ErrorRate")
+class ErrorRate(LMOperationalMetric):
+    """Fraction of LM calls that failed: failed / (succeeded + failed).
+
+    The headline reliability signal: successful calls bump `calls`, failures
+    bump `failed_calls`, so the error rate is observable even though failures
+    leave the token / cost / latency counters untouched.
+    """
+
+    def __init__(self, name="error_rate"):
+        super().__init__(name=name)
+
+    def result(self):
+        failed = self._delta("failed_calls")
+        total = self._delta("calls") + failed
+        if total <= 0:
+            return 0.0
+        return failed / total
+
+
 # ---------------------------------------------------------------------------
 # Reward-phase metrics
 # ---------------------------------------------------------------------------
@@ -397,6 +529,62 @@ class AvgRewardOutputTokensPerCall(LMRewardsOperationalMetric):
         return self._delta("completion_tokens") / calls
 
 
+@synalinks_export("synalinks.metrics.AvgRewardTotalTokensPerCall")
+class AvgRewardTotalTokensPerCall(LMRewardsOperationalMetric):
+    """Average total tokens per LM call during reward computation."""
+
+    def __init__(self, name="avg_reward_total_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("tokens") / calls
+
+
+@synalinks_export("synalinks.metrics.AvgRewardCachedTokensPerCall")
+class AvgRewardCachedTokensPerCall(LMRewardsOperationalMetric):
+    """Average cached prompt tokens per LM call during reward computation."""
+
+    def __init__(self, name="avg_reward_cached_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("cached_tokens") / calls
+
+
+@synalinks_export("synalinks.metrics.AvgRewardCacheCreationTokensPerCall")
+class AvgRewardCacheCreationTokensPerCall(LMRewardsOperationalMetric):
+    """Average cache-creation tokens per LM call during reward computation."""
+
+    def __init__(self, name="avg_reward_cache_creation_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("cache_creation_tokens") / calls
+
+
+@synalinks_export("synalinks.metrics.AvgRewardReasoningTokensPerCall")
+class AvgRewardReasoningTokensPerCall(LMRewardsOperationalMetric):
+    """Average reasoning tokens per LM call during reward computation."""
+
+    def __init__(self, name="avg_reward_reasoning_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("reasoning_tokens") / calls
+
+
 @synalinks_export("synalinks.metrics.RewardTokensPerSecond")
 class RewardTokensPerSecond(LMRewardsOperationalMetric):
     """Throughput in tokens per second during reward computation."""
@@ -405,10 +593,10 @@ class RewardTokensPerSecond(LMRewardsOperationalMetric):
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("tokens") / elapsed
+        return self._delta("tokens") / wall
 
 
 @synalinks_export("synalinks.metrics.RewardThroughput")
@@ -419,10 +607,24 @@ class RewardThroughput(LMRewardsOperationalMetric):
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("calls") / elapsed
+        return self._delta("calls") / wall
+
+
+@synalinks_export("synalinks.metrics.AvgRewardLatency")
+class AvgRewardLatency(LMRewardsOperationalMetric):
+    """Average wall-clock latency (s) per LM call during reward computation."""
+
+    def __init__(self, name="avg_reward_latency"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("elapsed_s") / calls
 
 
 @synalinks_export("synalinks.metrics.RewardCost")
@@ -511,6 +713,43 @@ class RewardReasoningTokenShare(LMRewardsOperationalMetric):
         return self._delta("reasoning_tokens") / completion
 
 
+@synalinks_export("synalinks.metrics.RewardFailedCalls")
+class RewardFailedCalls(LMRewardsOperationalMetric):
+    """LM calls that failed during reward computation."""
+
+    def __init__(self, name="reward_failed_calls"):
+        super().__init__(name=name)
+
+    def result(self):
+        return int(self._delta("failed_calls"))
+
+
+@synalinks_export("synalinks.metrics.RewardFallbackActivations")
+class RewardFallbackActivations(LMRewardsOperationalMetric):
+    """Fallback activations triggered during reward computation."""
+
+    def __init__(self, name="reward_fallback_activations"):
+        super().__init__(name=name)
+
+    def result(self):
+        return int(self._delta("fallback_activations"))
+
+
+@synalinks_export("synalinks.metrics.RewardErrorRate")
+class RewardErrorRate(LMRewardsOperationalMetric):
+    """Fraction of LM calls that failed during reward computation."""
+
+    def __init__(self, name="reward_error_rate"):
+        super().__init__(name=name)
+
+    def result(self):
+        failed = self._delta("failed_calls")
+        total = self._delta("calls") + failed
+        if total <= 0:
+            return 0.0
+        return failed / total
+
+
 # ---------------------------------------------------------------------------
 # Optimizer-phase metrics
 # ---------------------------------------------------------------------------
@@ -595,6 +834,62 @@ class AvgOptimizerOutputTokensPerCall(LMOptimizersOperationalMetric):
         return self._delta("completion_tokens") / calls
 
 
+@synalinks_export("synalinks.metrics.AvgOptimizerTotalTokensPerCall")
+class AvgOptimizerTotalTokensPerCall(LMOptimizersOperationalMetric):
+    """Average total tokens per LM call during the optimizer step."""
+
+    def __init__(self, name="avg_optimizer_total_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("tokens") / calls
+
+
+@synalinks_export("synalinks.metrics.AvgOptimizerCachedTokensPerCall")
+class AvgOptimizerCachedTokensPerCall(LMOptimizersOperationalMetric):
+    """Average cached prompt tokens per LM call during the optimizer step."""
+
+    def __init__(self, name="avg_optimizer_cached_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("cached_tokens") / calls
+
+
+@synalinks_export("synalinks.metrics.AvgOptimizerCacheCreationTokensPerCall")
+class AvgOptimizerCacheCreationTokensPerCall(LMOptimizersOperationalMetric):
+    """Average cache-creation tokens per LM call during the optimizer step."""
+
+    def __init__(self, name="avg_optimizer_cache_creation_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("cache_creation_tokens") / calls
+
+
+@synalinks_export("synalinks.metrics.AvgOptimizerReasoningTokensPerCall")
+class AvgOptimizerReasoningTokensPerCall(LMOptimizersOperationalMetric):
+    """Average reasoning tokens per LM call during the optimizer step."""
+
+    def __init__(self, name="avg_optimizer_reasoning_tokens_per_call"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("reasoning_tokens") / calls
+
+
 @synalinks_export("synalinks.metrics.OptimizerTokensPerSecond")
 class OptimizerTokensPerSecond(LMOptimizersOperationalMetric):
     """Throughput in tokens per second during the optimizer step."""
@@ -603,10 +898,10 @@ class OptimizerTokensPerSecond(LMOptimizersOperationalMetric):
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("tokens") / elapsed
+        return self._delta("tokens") / wall
 
 
 @synalinks_export("synalinks.metrics.OptimizerThroughput")
@@ -617,10 +912,24 @@ class OptimizerThroughput(LMOptimizersOperationalMetric):
         super().__init__(name=name)
 
     def result(self):
-        elapsed = self._delta("elapsed_s")
-        if elapsed <= 0.0:
+        wall = self._wall_clock_delta()
+        if wall <= 0.0:
             return 0.0
-        return self._delta("calls") / elapsed
+        return self._delta("calls") / wall
+
+
+@synalinks_export("synalinks.metrics.AvgOptimizerLatency")
+class AvgOptimizerLatency(LMOptimizersOperationalMetric):
+    """Average wall-clock latency (s) per LM call during the optimizer step."""
+
+    def __init__(self, name="avg_optimizer_latency"):
+        super().__init__(name=name)
+
+    def result(self):
+        calls = self._delta("calls")
+        if calls <= 0:
+            return 0.0
+        return self._delta("elapsed_s") / calls
 
 
 @synalinks_export("synalinks.metrics.OptimizerCost")
@@ -707,3 +1016,40 @@ class OptimizerReasoningTokenShare(LMOptimizersOperationalMetric):
         if completion <= 0:
             return 0.0
         return self._delta("reasoning_tokens") / completion
+
+
+@synalinks_export("synalinks.metrics.OptimizerFailedCalls")
+class OptimizerFailedCalls(LMOptimizersOperationalMetric):
+    """LM calls that failed during the optimizer step."""
+
+    def __init__(self, name="optimizer_failed_calls"):
+        super().__init__(name=name)
+
+    def result(self):
+        return int(self._delta("failed_calls"))
+
+
+@synalinks_export("synalinks.metrics.OptimizerFallbackActivations")
+class OptimizerFallbackActivations(LMOptimizersOperationalMetric):
+    """Fallback activations triggered during the optimizer step."""
+
+    def __init__(self, name="optimizer_fallback_activations"):
+        super().__init__(name=name)
+
+    def result(self):
+        return int(self._delta("fallback_activations"))
+
+
+@synalinks_export("synalinks.metrics.OptimizerErrorRate")
+class OptimizerErrorRate(LMOptimizersOperationalMetric):
+    """Fraction of LM calls that failed during the optimizer step."""
+
+    def __init__(self, name="optimizer_error_rate"):
+        super().__init__(name=name)
+
+    def result(self):
+        failed = self._delta("failed_calls")
+        total = self._delta("calls") + failed
+        if total <= 0:
+            return 0.0
+        return failed / total

--- a/synalinks/src/metrics/lm_metrics_test.py
+++ b/synalinks/src/metrics/lm_metrics_test.py
@@ -1,25 +1,53 @@
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
+import asyncio
+from unittest import mock
+
 from synalinks.src import testing
-from synalinks.src.backend.common import global_state
+from synalinks.src.backend.common.global_state import clear_session
+from synalinks.src.backend.common.op_scope import _add_phase_wall_clock_s
+from synalinks.src.backend.common.op_scope import current_op_scope
+from synalinks.src.backend.common.op_scope import op_scope
+from synalinks.src.backend.common.op_scope import read_phase_wall_clock_s
+from synalinks.src.metrics.lm_metrics import AvgCacheCreationTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgCachedTokensPerCall
 from synalinks.src.metrics.lm_metrics import AvgCostPerCall
 from synalinks.src.metrics.lm_metrics import AvgInputTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgLatency
+from synalinks.src.metrics.lm_metrics import AvgOptimizerCacheCreationTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgOptimizerCachedTokensPerCall
 from synalinks.src.metrics.lm_metrics import AvgOptimizerCostPerCall
 from synalinks.src.metrics.lm_metrics import AvgOptimizerInputTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgOptimizerLatency
 from synalinks.src.metrics.lm_metrics import AvgOptimizerOutputTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgOptimizerReasoningTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgOptimizerTotalTokensPerCall
 from synalinks.src.metrics.lm_metrics import AvgOutputTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgReasoningTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgRewardCacheCreationTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgRewardCachedTokensPerCall
 from synalinks.src.metrics.lm_metrics import AvgRewardCostPerCall
 from synalinks.src.metrics.lm_metrics import AvgRewardInputTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgRewardLatency
 from synalinks.src.metrics.lm_metrics import AvgRewardOutputTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgRewardReasoningTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgRewardTotalTokensPerCall
+from synalinks.src.metrics.lm_metrics import AvgTotalTokensPerCall
 from synalinks.src.metrics.lm_metrics import CacheCreationTokens
 from synalinks.src.metrics.lm_metrics import CachedTokens
 from synalinks.src.metrics.lm_metrics import CacheHitRate
 from synalinks.src.metrics.lm_metrics import Cost
+from synalinks.src.metrics.lm_metrics import ErrorRate
+from synalinks.src.metrics.lm_metrics import FailedCalls
+from synalinks.src.metrics.lm_metrics import FallbackActivations
 from synalinks.src.metrics.lm_metrics import InputTokens
 from synalinks.src.metrics.lm_metrics import OptimizerCacheCreationTokens
 from synalinks.src.metrics.lm_metrics import OptimizerCachedTokens
 from synalinks.src.metrics.lm_metrics import OptimizerCacheHitRate
 from synalinks.src.metrics.lm_metrics import OptimizerCost
+from synalinks.src.metrics.lm_metrics import OptimizerErrorRate
+from synalinks.src.metrics.lm_metrics import OptimizerFailedCalls
+from synalinks.src.metrics.lm_metrics import OptimizerFallbackActivations
 from synalinks.src.metrics.lm_metrics import OptimizerInputTokens
 from synalinks.src.metrics.lm_metrics import OptimizerReasoningTokens
 from synalinks.src.metrics.lm_metrics import OptimizerReasoningTokenShare
@@ -33,6 +61,9 @@ from synalinks.src.metrics.lm_metrics import RewardCacheCreationTokens
 from synalinks.src.metrics.lm_metrics import RewardCachedTokens
 from synalinks.src.metrics.lm_metrics import RewardCacheHitRate
 from synalinks.src.metrics.lm_metrics import RewardCost
+from synalinks.src.metrics.lm_metrics import RewardErrorRate
+from synalinks.src.metrics.lm_metrics import RewardFailedCalls
+from synalinks.src.metrics.lm_metrics import RewardFallbackActivations
 from synalinks.src.metrics.lm_metrics import RewardInputTokens
 from synalinks.src.metrics.lm_metrics import RewardReasoningTokens
 from synalinks.src.metrics.lm_metrics import RewardReasoningTokenShare
@@ -130,10 +161,24 @@ class OperationalMetricsResultTest(testing.TestCase):
         lm = _stub_lm()
         m_tps = _bind(TokensPerSecond(), [lm])
         m_rps = _bind(Throughput(), [lm])
+        # Two calls of 2s each (summed elapsed = 4s) that ran concurrently in
+        # a 2s wall-clock window. Throughput divides by wall-clock, so it
+        # reflects real RPS (2/2) rather than the deflated 2/4 the old
+        # summed-elapsed denominator would give.
+        _add_phase_wall_clock_s("inference", 2.0)
         _record(lm, prompt=400, completion=100, elapsed=2.0, cost=0.0)
         _record(lm, prompt=400, completion=100, elapsed=2.0, cost=0.0)
-        self.assertEqual(m_tps.result(), 1000 / 4.0)
-        self.assertEqual(m_rps.result(), 2 / 4.0)
+        self.assertEqual(m_tps.result(), 1000 / 2.0)
+        self.assertEqual(m_rps.result(), 2 / 2.0)
+
+    def test_avg_latency(self):
+        lm = _stub_lm()
+        m_lat = _bind(AvgLatency(), [lm])
+        _record(lm, prompt=400, completion=100, elapsed=2.0, cost=0.0)
+        _record(lm, prompt=400, completion=100, elapsed=3.0, cost=0.0)
+        # Mean per-call latency = summed call time / calls = 5.0 / 2
+        # (unchanged by the wall-clock throughput switch).
+        self.assertEqual(m_lat.result(), 5.0 / 2)
 
     def test_cost_metrics(self):
         lm = _stub_lm()
@@ -143,6 +188,43 @@ class OperationalMetricsResultTest(testing.TestCase):
         _record(lm, prompt=10, completion=5, elapsed=0.1, cost=0.005)
         self.assertAlmostEqual(m_cost.result(), 0.008)
         self.assertAlmostEqual(m_avg.result(), 0.004)
+
+    def test_total_tokens_average(self):
+        lm = _stub_lm()
+        m = _bind(AvgTotalTokensPerCall(), [lm])
+        _record(lm, prompt=100, completion=20, elapsed=0.1, cost=0.0)
+        _record(lm, prompt=300, completion=80, elapsed=0.1, cost=0.0)
+        # total tokens = 120 + 380 = 500 over 2 calls.
+        self.assertEqual(m.result(), 250.0)
+
+    def test_extra_token_averages(self):
+        lm = _stub_lm_with_extras()
+        m_cached = _bind(AvgCachedTokensPerCall(), [lm])
+        m_cachecreate = _bind(AvgCacheCreationTokensPerCall(), [lm])
+        m_reasoning = _bind(AvgReasoningTokensPerCall(), [lm])
+        _record(lm, prompt=100, completion=20, elapsed=0.1, cost=0.0)
+        _record(lm, prompt=100, completion=20, elapsed=0.1, cost=0.0)
+        _bump(lm, "cached_tokens", 60, phase="inference")
+        _bump(lm, "cache_creation_tokens", 40, phase="inference")
+        _bump(lm, "reasoning_tokens", 30, phase="inference")
+        self.assertEqual(m_cached.result(), 30.0)  # 60 / 2
+        self.assertEqual(m_cachecreate.result(), 20.0)  # 40 / 2
+        self.assertEqual(m_reasoning.result(), 15.0)  # 30 / 2
+
+    def test_failure_metrics(self):
+        lm = _stub_lm()
+        m_failed = _bind(FailedCalls(), [lm])
+        m_fallback = _bind(FallbackActivations(), [lm])
+        m_error = _bind(ErrorRate(), [lm])
+        # 3 successful calls; 1 failed call that fell back.
+        _record(lm, prompt=10, completion=5, elapsed=0.1, cost=0.0)
+        _record(lm, prompt=10, completion=5, elapsed=0.1, cost=0.0)
+        _record(lm, prompt=10, completion=5, elapsed=0.1, cost=0.0)
+        _bump(lm, "failed_calls", 1, phase="inference")
+        _bump(lm, "fallback_activations", 1, phase="inference")
+        self.assertEqual(m_failed.result(), 1)
+        self.assertEqual(m_fallback.result(), 1)
+        self.assertEqual(m_error.result(), 1 / 4)  # failed / (succeeded + failed)
 
     def test_reset_state_snapshots_baseline(self):
         lm = _stub_lm()
@@ -159,9 +241,15 @@ class OperationalMetricsResultTest(testing.TestCase):
         m_avg_in = _bind(AvgInputTokensPerCall(), [lm])
         m_tps = _bind(TokensPerSecond(), [lm])
         m_rps = _bind(Throughput(), [lm])
+        m_lat = _bind(AvgLatency(), [lm])
+        m_avg_total = _bind(AvgTotalTokensPerCall(), [lm])
+        m_error = _bind(ErrorRate(), [lm])
         self.assertEqual(m_avg_in.result(), 0.0)
         self.assertEqual(m_tps.result(), 0.0)
         self.assertEqual(m_rps.result(), 0.0)
+        self.assertEqual(m_lat.result(), 0.0)
+        self.assertEqual(m_avg_total.result(), 0.0)
+        self.assertEqual(m_error.result(), 0.0)
 
     def test_result_is_zero_before_bind(self):
         # No bind_program() call → no LMs → metric reports 0 instead of crashing.
@@ -263,28 +351,62 @@ class LMPhaseRoutingTest(testing.TestCase):
         self.assertAlmostEqual(m.result(), 0.005)
 
 
-class OpScopeFlagTest(testing.TestCase):
-    """The trainer sets ``global_state["synalinks_op_scope"]`` to one of
-    "inference" | "reward" | "optimizer" | None, and the LM/EM route
-    counter updates based on the value. Pin the contract here so a future
-    refactor doesn't silently break attribution.
+class OpScopeTest(testing.TestCase):
+    """`op_scope` marks a region as inference/reward/optimizer so the LM/EM
+    attribute calls to a phase and throughput can use the phase's wall-clock.
+    It is contextvars-backed (propagates into concurrent child tasks, unlike a
+    threading.local) and accrues per-phase wall-clock with a nesting stack.
+    Pin the contract so a refactor can't silently break attribution.
     """
 
-    def test_scope_default_is_none(self):
-        global_state.set_global_attribute("synalinks_op_scope", None)
-        self.assertIsNone(global_state.get_global_attribute("synalinks_op_scope"))
+    def test_default_scope_is_none(self):
+        self.assertIsNone(current_op_scope())
 
-    def test_scope_round_trip(self):
-        prev = global_state.get_global_attribute("synalinks_op_scope")
-        try:
-            for value in ("inference", "reward", "optimizer"):
-                global_state.set_global_attribute("synalinks_op_scope", value)
-                self.assertEqual(
-                    global_state.get_global_attribute("synalinks_op_scope"),
-                    value,
-                )
-        finally:
-            global_state.set_global_attribute("synalinks_op_scope", prev)
+    def test_context_manager_sets_and_restores(self):
+        self.assertIsNone(current_op_scope())
+        with op_scope("reward"):
+            self.assertEqual(current_op_scope(), "reward")
+            with op_scope("optimizer"):
+                self.assertEqual(current_op_scope(), "optimizer")
+            self.assertEqual(current_op_scope(), "reward")
+        self.assertIsNone(current_op_scope())
+
+    def test_propagates_into_concurrent_child_tasks(self):
+        # The reason for contextvars over threading.local: a scope entered
+        # before asyncio.gather() is inherited by every child coroutine (this
+        # is exactly the trainer's compute_reward / predict_on_batch pattern),
+        # so concurrent LM calls are all attributed to the right phase.
+        async def _run():
+            async def observe():
+                await asyncio.sleep(0)  # force interleaving
+                return current_op_scope()
+
+            with op_scope("reward"):
+                in_reward = await asyncio.gather(*[observe() for _ in range(5)])
+            with op_scope("optimizer"):
+                in_optimizer = await asyncio.gather(*[observe() for _ in range(5)])
+            return in_reward, in_optimizer
+
+        in_reward, in_optimizer = asyncio.run(_run())
+        self.assertEqual(in_reward, ["reward"] * 5)
+        self.assertEqual(in_optimizer, ["optimizer"] * 5)
+
+    def test_nested_wall_clock_is_self_time(self):
+        # Optimizer wraps reward; each phase should be credited only its own
+        # time, so the nested reward span is not double-counted on optimizer.
+        clear_session()  # reset the (thread-local) wall-clock accumulators
+        # perf_counter() is called once per enter and once per exit:
+        # enter(opt)=0, enter(rew)=2, exit(rew)=5, exit(opt)=9
+        ticks = [0.0, 2.0, 5.0, 9.0]
+        with mock.patch(
+            "synalinks.src.backend.common.op_scope.time.perf_counter",
+            side_effect=ticks,
+        ):
+            with op_scope("optimizer"):
+                with op_scope("reward"):
+                    pass
+        self.assertEqual(read_phase_wall_clock_s("reward"), 3.0)  # 5 - 2
+        self.assertEqual(read_phase_wall_clock_s("optimizer"), 6.0)  # (2-0)+(9-5)
 
 
 # The reward- and optimizer-phase metric classes mirror the inference set
@@ -319,6 +441,7 @@ class LMRatesAndCachePerPhaseTest(testing.TestCase):
             "inference",
             TokensPerSecond,
             Throughput,
+            AvgLatency,
             AvgInputTokensPerCall,
             AvgOutputTokensPerCall,
             AvgCostPerCall,
@@ -332,6 +455,7 @@ class LMRatesAndCachePerPhaseTest(testing.TestCase):
             "reward",
             RewardTokensPerSecond,
             RewardThroughput,
+            AvgRewardLatency,
             AvgRewardInputTokensPerCall,
             AvgRewardOutputTokensPerCall,
             AvgRewardCostPerCall,
@@ -345,6 +469,7 @@ class LMRatesAndCachePerPhaseTest(testing.TestCase):
             "optimizer",
             OptimizerTokensPerSecond,
             OptimizerThroughput,
+            AvgOptimizerLatency,
             AvgOptimizerInputTokensPerCall,
             AvgOptimizerOutputTokensPerCall,
             AvgOptimizerCostPerCall,
@@ -361,6 +486,7 @@ class LMRatesAndCachePerPhaseTest(testing.TestCase):
             phase,
             Tps,
             Rps,
+            Lat,
             AvgIn,
             AvgOut,
             AvgCost,
@@ -375,6 +501,7 @@ class LMRatesAndCachePerPhaseTest(testing.TestCase):
                 metrics = {
                     "tps": _bind(Tps(), [lm]),
                     "rps": _bind(Rps(), [lm]),
+                    "lat": _bind(Lat(), [lm]),
                     "avg_in": _bind(AvgIn(), [lm]),
                     "avg_out": _bind(AvgOut(), [lm]),
                     "avg_cost": _bind(AvgCost(), [lm]),
@@ -388,6 +515,7 @@ class LMRatesAndCachePerPhaseTest(testing.TestCase):
                 ratio_keys = (
                     "tps",
                     "rps",
+                    "lat",
                     "avg_in",
                     "avg_out",
                     "avg_cost",
@@ -410,9 +538,11 @@ class LMRatesAndCachePerPhaseTest(testing.TestCase):
                 _bump(lm, "cached_tokens", 50, phase=phase)
                 _bump(lm, "cache_creation_tokens", 10, phase=phase)
                 _bump(lm, "reasoning_tokens", 40, phase=phase)
+                _add_phase_wall_clock_s(phase, 4.0)  # throughput denominator
 
                 self.assertEqual(metrics["tps"].result(), 500 / 4.0)
                 self.assertEqual(metrics["rps"].result(), 2 / 4.0)
+                self.assertEqual(metrics["lat"].result(), 4.0 / 2)
                 self.assertEqual(metrics["avg_in"].result(), 200.0)
                 self.assertEqual(metrics["avg_out"].result(), 50.0)
                 self.assertAlmostEqual(metrics["avg_cost"].result(), 0.002)
@@ -421,3 +551,91 @@ class LMRatesAndCachePerPhaseTest(testing.TestCase):
                 self.assertEqual(metrics["hit_rate"].result(), 50 / 400)
                 self.assertEqual(metrics["reasoning"].result(), 40)
                 self.assertEqual(metrics["r_share"].result(), 40 / 100)
+
+
+class LMExtraAveragesPerPhaseTest(testing.TestCase):
+    """Extra per-call token averages (total / cached / cache-creation /
+    reasoning) for the reward and optimizer phases. The inference variants
+    are covered by dedicated tests above."""
+
+    PHASES = (
+        (
+            "reward",
+            AvgRewardTotalTokensPerCall,
+            AvgRewardCachedTokensPerCall,
+            AvgRewardCacheCreationTokensPerCall,
+            AvgRewardReasoningTokensPerCall,
+        ),
+        (
+            "optimizer",
+            AvgOptimizerTotalTokensPerCall,
+            AvgOptimizerCachedTokensPerCall,
+            AvgOptimizerCacheCreationTokensPerCall,
+            AvgOptimizerReasoningTokensPerCall,
+        ),
+    )
+
+    def test_extra_averages_per_phase(self):
+        for (
+            phase,
+            AvgTotal,
+            AvgCached,
+            AvgCacheCreate,
+            AvgReasoning,
+        ) in self.PHASES:
+            with self.subTest(phase=phase):
+                lm = _stub_lm_with_extras()
+                m_total = _bind(AvgTotal(), [lm])
+                m_cached = _bind(AvgCached(), [lm])
+                m_cachecreate = _bind(AvgCacheCreate(), [lm])
+                m_reasoning = _bind(AvgReasoning(), [lm])
+                # Zero-state.
+                self.assertEqual(m_total.result(), 0.0)
+                self.assertEqual(m_cached.result(), 0.0)
+                self.assertEqual(m_cachecreate.result(), 0.0)
+                self.assertEqual(m_reasoning.result(), 0.0)
+                # 2 calls, 500 total tokens, 60 cached, 40 cache-creation,
+                # 30 reasoning.
+                _record(lm, prompt=100, completion=20, elapsed=0.1, cost=0.0, phase=phase)
+                _record(lm, prompt=300, completion=80, elapsed=0.1, cost=0.0, phase=phase)
+                _bump(lm, "cached_tokens", 60, phase=phase)
+                _bump(lm, "cache_creation_tokens", 40, phase=phase)
+                _bump(lm, "reasoning_tokens", 30, phase=phase)
+                self.assertEqual(m_total.result(), 250.0)  # 500 / 2
+                self.assertEqual(m_cached.result(), 30.0)  # 60 / 2
+                self.assertEqual(m_cachecreate.result(), 20.0)  # 40 / 2
+                self.assertEqual(m_reasoning.result(), 15.0)  # 30 / 2
+
+
+class LMFailureMetricsPerPhaseTest(testing.TestCase):
+    """`FailedCalls` / `FallbackActivations` / `ErrorRate` for the reward and
+    optimizer phases (inference is covered by a dedicated test above)."""
+
+    PHASES = (
+        ("reward", RewardFailedCalls, RewardFallbackActivations, RewardErrorRate),
+        (
+            "optimizer",
+            OptimizerFailedCalls,
+            OptimizerFallbackActivations,
+            OptimizerErrorRate,
+        ),
+    )
+
+    def test_failure_metrics_per_phase(self):
+        for phase, FailedM, FallbackM, ErrorM in self.PHASES:
+            with self.subTest(phase=phase):
+                lm = _stub_lm()
+                m_failed = _bind(FailedM(), [lm])
+                m_fallback = _bind(FallbackM(), [lm])
+                m_error = _bind(ErrorM(), [lm])
+                # Zero-state: error rate guarded against no calls.
+                self.assertEqual(m_failed.result(), 0)
+                self.assertEqual(m_fallback.result(), 0)
+                self.assertEqual(m_error.result(), 0.0)
+                # 1 success, 3 failed (2 of which fell back).
+                _record(lm, prompt=10, completion=5, elapsed=0.1, cost=0.0, phase=phase)
+                _bump(lm, "failed_calls", 3, phase=phase)
+                _bump(lm, "fallback_activations", 2, phase=phase)
+                self.assertEqual(m_failed.result(), 3)
+                self.assertEqual(m_fallback.result(), 2)
+                self.assertEqual(m_error.result(), 3 / 4)  # 3 failed / (1 + 3)

--- a/synalinks/src/metrics/program_metrics.py
+++ b/synalinks/src/metrics/program_metrics.py
@@ -35,8 +35,8 @@ class ProgramOperationalMetric(Metric):
 
     Subclasses set `_phase` to one of ``"inference"``, ``"reward"``, or
     ``"optimizer"`` to read the corresponding counter set. Counters are
-    populated based on the ``synalinks_op_scope`` global flag set by the
-    trainer.
+    populated based on the active ``op_scope`` (contextvar) the trainer
+    sets for each phase.
     """
 
     _phase = "inference"

--- a/synalinks/src/metrics/program_metrics_test.py
+++ b/synalinks/src/metrics/program_metrics_test.py
@@ -208,7 +208,7 @@ class ProgramOperationalMetricsIntegrationTest(testing.TestCase):
     """
 
     async def test_metric_reads_real_invocations(self):
-        from synalinks.src.backend.common import global_state
+        from synalinks.src.backend.common.op_scope import op_scope
 
         class Query(backend.DataModel):
             query: str
@@ -217,18 +217,15 @@ class ProgramOperationalMetricsIntegrationTest(testing.TestCase):
         metric = ProgramCalls()
         metric.bind_program(module)
 
-        global_state.set_global_attribute("synalinks_op_scope", "inference")
-        try:
+        with op_scope("inference"):
             await module(backend.SymbolicDataModel(data_model=Query))
             await module(backend.SymbolicDataModel(data_model=Query))
             await module(backend.SymbolicDataModel(data_model=Query))
-        finally:
-            global_state.set_global_attribute("synalinks_op_scope", None)
 
         self.assertEqual(metric.result(), 3)
 
     async def test_metric_reads_real_elapsed(self):
-        from synalinks.src.backend.common import global_state
+        from synalinks.src.backend.common.op_scope import op_scope
 
         class Query(backend.DataModel):
             query: str
@@ -237,11 +234,8 @@ class ProgramOperationalMetricsIntegrationTest(testing.TestCase):
         metric = ProgramElapsedTime()
         metric.bind_program(module)
 
-        global_state.set_global_attribute("synalinks_op_scope", "inference")
-        try:
+        with op_scope("inference"):
             await module(backend.SymbolicDataModel(data_model=Query))
-        finally:
-            global_state.set_global_attribute("synalinks_op_scope", None)
 
         # Real elapsed; just assert positive and finite.
         result = metric.result()

--- a/synalinks/src/modules/embedding_models/embedding_model.py
+++ b/synalinks/src/modules/embedding_models/embedding_model.py
@@ -14,7 +14,7 @@ from tenacity import wait_exponential
 from synalinks.src.api_export import synalinks_export
 from synalinks.src.backend import Embeddings
 from synalinks.src.backend import JsonDataModel
-from synalinks.src.backend.common import global_state
+from synalinks.src.backend.common.op_scope import current_op_scope
 from synalinks.src.modules.module import Module
 from synalinks.src.saving import serialization_lib
 
@@ -221,6 +221,10 @@ class EmbeddingModel(Module):
         self.cumulated_elapsed_s = 0.0
         self.cumulated_cost = 0.0
         self.cumulated_cached_tokens = 0
+        # Failure counters: a call that exhausts all retries (`failed_calls`)
+        # and each `fallback` invocation it triggers (`fallback_activations`).
+        self.cumulated_failed_calls = 0
+        self.cumulated_fallback_activations = 0
         self.cumulated_details = {}
         self.last_call_prompt_tokens = 0
         self.last_call_tokens = 0
@@ -240,10 +244,22 @@ class EmbeddingModel(Module):
             setattr(self, f"{_phase}_cumulated_elapsed_s", 0.0)
             setattr(self, f"{_phase}_cumulated_cost", 0.0)
             setattr(self, f"{_phase}_cumulated_cached_tokens", 0)
+            setattr(self, f"{_phase}_cumulated_failed_calls", 0)
+            setattr(self, f"{_phase}_cumulated_fallback_activations", 0)
             setattr(self, f"{_phase}_cumulated_details", {})
         # No state depends on the input shape, so mark built up-front and
         # skip Module's auto-build path (which would try to trace `call`).
         self.built = True
+
+    def _record_event(self, suffix):
+        """Bump an all-time + phase-scoped operational counter by 1 (used for
+        `failed_calls` / `fallback_activations`), attributed to the active
+        `op_scope` like the successful-call counters.
+        """
+        op = current_op_scope()
+        _accumulate(self, "", {suffix: 1}, None)
+        if op is not None:
+            _accumulate(self, f"{op}_", {suffix: 1}, None)
 
     async def call(self, inputs, **kwargs):
         """
@@ -265,7 +281,9 @@ class EmbeddingModel(Module):
             return await self._call_with_retry(texts, **kwargs)
         except Exception as e:
             warnings.warn(f"All retries failed for {self}: {e}")
+            self._record_event("failed_calls")
             if self.fallback:
+                self._record_event("fallback_activations")
                 return await self.fallback(
                     inputs,
                     **input_kwargs,
@@ -302,9 +320,7 @@ class EmbeddingModel(Module):
                         **kwargs,
                     )
                 elapsed_s = time.perf_counter() - t0
-                op_scope = global_state.get_global_attribute("synalinks_op_scope")
-                if op_scope not in ("inference", "reward", "optimizer"):
-                    op_scope = None
+                op_scope = current_op_scope()
                 response_cost = None
                 if hasattr(response, "_hidden_params"):
                     if "response_cost" in response._hidden_params:

--- a/synalinks/src/modules/embedding_models/embedding_model_test.py
+++ b/synalinks/src/modules/embedding_models/embedding_model_test.py
@@ -10,7 +10,7 @@ from litellm.types.utils import Usage
 from synalinks.src import testing
 from synalinks.src.backend import EmbeddingRequest
 from synalinks.src.backend import Embeddings
-from synalinks.src.backend.common import global_state
+from synalinks.src.backend.common.op_scope import _OP_SCOPE
 from synalinks.src.modules.embedding_models.embedding_model import EmbeddingModel
 
 
@@ -95,7 +95,9 @@ def _em_response(prompt_tokens, n_vectors, cost=None):
 
 
 def _set_scope(value):
-    global_state.set_global_attribute("synalinks_op_scope", value)
+    # Phase scope is contextvars-backed; set it directly on the current
+    # context for these counter-routing tests (wall-clock is unaffected).
+    _OP_SCOPE.set(value)
 
 
 class EMCounterPopulationTest(testing.TestCase):

--- a/synalinks/src/modules/language_models/language_model.py
+++ b/synalinks/src/modules/language_models/language_model.py
@@ -18,7 +18,7 @@ from synalinks.src.backend import ChatMessage
 from synalinks.src.backend import ChatMessages
 from synalinks.src.backend import ChatRole
 from synalinks.src.backend import JsonDataModel
-from synalinks.src.backend.common import global_state
+from synalinks.src.backend.common.op_scope import current_op_scope
 from synalinks.src.modules.core.tool import Tool
 from synalinks.src.modules.module import Module
 from synalinks.src.saving import serialization_lib
@@ -424,6 +424,33 @@ class LanguageModel(Module):
     putting your API keys in the code or a config file that can lead to
     leackage when pushing it into repositories.
 
+    **Controlling reasoning effort**
+
+    Reasoning ("thinking") models can be steered with the `reasoning_effort`
+    parameter, passed either as a default in the constructor or per call. It
+    accepts:
+
+    - `"none"` (the default): send nothing, leaving the model at its provider
+      default reasoning behavior.
+    - `"disable"`: actively turn native reasoning *off*. This only has an
+      effect for providers that reason by default, i.e. ollama's thinking
+      models (`qwen3`, `deepseek-r1`, ...); it maps to ollama's `think=False`
+      toggle and is safely ignored by non-thinking ollama models. Opt-in
+      providers (OpenAI, Anthropic, Gemini, ...) reason only when explicitly
+      enabled, so there is nothing to send and this value is a no-op for them.
+    - any other value (e.g. `"low"`, `"medium"`, `"high"`): forwarded to the
+      provider as the reasoning effort, but only when the model supports
+      reasoning (otherwise it is silently dropped).
+
+    ```python
+    import synalinks
+
+    language_model = synalinks.LanguageModel(
+        model="openai/o3-mini",
+        reasoning_effort="medium",
+    )
+    ```
+
     Args:
         model (str): The model to use.
         api_base (str): Optional. The endpoint to use.
@@ -437,7 +464,9 @@ class LanguageModel(Module):
         hooks (list): Optional. Hooks to attach to this module's calls.
         **default_kwargs: Optional. Default generation parameters (e.g.
             `temperature`, `top_p`, `top_k`, `max_tokens`, `reasoning_effort`)
-            forwarded to every call. Per-call kwargs override these.
+            forwarded to every call. Per-call kwargs override these. See
+            "Controlling reasoning effort" above for the `reasoning_effort`
+            values and their semantics.
     """
 
     def __init__(
@@ -511,6 +540,12 @@ class LanguageModel(Module):
         self.cumulated_cached_tokens = 0
         self.cumulated_cache_creation_tokens = 0
         self.cumulated_reasoning_tokens = 0
+        # Failure counters: a call that exhausts all retries (`failed_calls`)
+        # and each time the `fallback` chain is invoked because of it
+        # (`fallback_activations`). Successful calls bump `cumulated_calls`;
+        # these are tracked separately so error rate is observable.
+        self.cumulated_failed_calls = 0
+        self.cumulated_fallback_activations = 0
         self.cumulated_details = {}
         self.last_call_prompt_tokens = 0
         self.last_call_completion_tokens = 0
@@ -536,10 +571,22 @@ class LanguageModel(Module):
             setattr(self, f"{_phase}_cumulated_cached_tokens", 0)
             setattr(self, f"{_phase}_cumulated_cache_creation_tokens", 0)
             setattr(self, f"{_phase}_cumulated_reasoning_tokens", 0)
+            setattr(self, f"{_phase}_cumulated_failed_calls", 0)
+            setattr(self, f"{_phase}_cumulated_fallback_activations", 0)
             setattr(self, f"{_phase}_cumulated_details", {})
         # No state depends on the input shape, so mark built up-front and
         # skip Module's auto-build path (which would try to trace `call`).
         self.built = True
+
+    def _record_event(self, suffix):
+        """Bump an all-time + phase-scoped operational counter by 1 (used for
+        `failed_calls` / `fallback_activations`). Phase follows the active
+        `op_scope`, matching how successful-call counters are attributed.
+        """
+        op = current_op_scope()
+        _accumulate(self, "", {suffix: 1}, None)
+        if op is not None:
+            _accumulate(self, f"{op}_", {suffix: 1}, None)
 
     async def call(self, messages, schema=None, tools=None, streaming=False, **kwargs):
         """
@@ -594,12 +641,24 @@ class LanguageModel(Module):
                 tools = tools.values()
             kwargs["tools"] = [_tool_to_wire(t) for t in tools]
 
-        # Handle reasoning_effort parameter - just forward to litellm if supported
+        # Handle reasoning_effort:
+        #   "none"    -> send nothing; leave the model at its provider default.
+        #   "disable" -> actively turn native reasoning OFF. This only needs an
+        #                explicit flag where reasoning is ON by default, i.e.
+        #                ollama's thinking models (qwen3, deepseek-r1, ...), which
+        #                reason unless told not to. `think=False` is the ollama
+        #                toggle and is safely ignored by non-thinking ollama
+        #                models. Opt-in providers (OpenAI, Anthropic, Gemini, ...)
+        #                reason only when enabled, so there is nothing to send.
+        #   otherwise -> forward the effort to litellm when the model supports it.
         reasoning_effort = kwargs.pop("reasoning_effort", "none")
         schema_had_thinking = bool(schema) and "thinking" in (
             schema.get("properties") or {}
         )
-        if reasoning_effort not in ("none", "disable"):
+        if reasoning_effort == "disable":
+            if self.model.startswith("ollama"):
+                kwargs["think"] = False
+        elif reasoning_effort != "none":
             if litellm.supports_reasoning(model=self.model):
                 kwargs["reasoning_effort"] = reasoning_effort
                 if schema_had_thinking:
@@ -766,7 +825,9 @@ class LanguageModel(Module):
             )
         except Exception as e:
             warnings.warn(f"All retries failed for {self}: {e}")
+            self._record_event("failed_calls")
             if self.fallback:
+                self._record_event("fallback_activations")
                 return await self.fallback(
                     messages,
                     schema=schema,
@@ -800,9 +861,7 @@ class LanguageModel(Module):
                     **kwargs,
                 )
                 elapsed_s = time.perf_counter() - t0
-                op_scope = global_state.get_global_attribute("synalinks_op_scope")
-                if op_scope not in ("inference", "reward", "optimizer"):
-                    op_scope = None
+                op_scope = current_op_scope()
                 response_cost = None
                 if hasattr(response, "_hidden_params"):
                     if "response_cost" in response._hidden_params:

--- a/synalinks/src/modules/language_models/language_model_test.py
+++ b/synalinks/src/modules/language_models/language_model_test.py
@@ -15,7 +15,7 @@ from synalinks.src.backend import ChatMessage
 from synalinks.src.backend import ChatMessages
 from synalinks.src.backend import ChatRole
 from synalinks.src.backend import DataModel
-from synalinks.src.backend.common import global_state
+from synalinks.src.backend.common.op_scope import _OP_SCOPE
 from synalinks.src.modules.language_models import LanguageModel
 
 
@@ -170,6 +170,44 @@ class LanguageModelTest(testing.TestCase):
         self.assertEqual(response_format["type"], "json_schema")
         self.assertEqual(response_format["json_schema"]["name"], "structured_output")
 
+    @patch("litellm.acompletion")
+    async def test_reasoning_effort_disable_sends_think_false_for_ollama(
+        self, mock_completion
+    ):
+        """`reasoning_effort="disable"` turns native thinking off on ollama
+        (which reasons by default) by sending `think=False`; `"none"` leaves the
+        model at its default and sends nothing.
+        """
+        mock_completion.return_value = {
+            "choices": [{"message": {"content": "ok"}}]
+        }
+        messages = ChatMessages(
+            messages=[ChatMessage(role=ChatRole.USER, content="Hello")]
+        )
+
+        ollama_lm = LanguageModel(model="ollama_chat/qwen3:8b")
+        await ollama_lm(messages, reasoning_effort="disable")
+        self.assertIs(mock_completion.call_args.kwargs.get("think"), False)
+
+        await ollama_lm(messages, reasoning_effort="none")
+        self.assertNotIn("think", mock_completion.call_args.kwargs)
+
+    @patch("litellm.acompletion")
+    async def test_reasoning_effort_disable_noop_for_non_ollama(self, mock_completion):
+        """Opt-in providers reason only when enabled, so "disable" sends no
+        `think` flag (it is ollama-specific and would be rejected elsewhere).
+        """
+        mock_completion.return_value = {
+            "choices": [{"message": {"content": "ok"}}]
+        }
+        messages = ChatMessages(
+            messages=[ChatMessage(role=ChatRole.USER, content="Hello")]
+        )
+
+        lm = LanguageModel(model="openai/gpt-4o-mini")
+        await lm(messages, reasoning_effort="disable")
+        self.assertNotIn("think", mock_completion.call_args.kwargs)
+
 
 def _lm_response(prompt_tokens, completion_tokens, total_tokens=None, cost=None):
     """Build a realistic LiteLLM ModelResponse (mirrors what acompletion returns)."""
@@ -203,7 +241,9 @@ def _chat_messages():
 
 
 def _set_scope(value):
-    global_state.set_global_attribute("synalinks_op_scope", value)
+    # Phase scope is contextvars-backed; set it directly on the current
+    # context for these counter-routing tests (wall-clock is unaffected).
+    _OP_SCOPE.set(value)
 
 
 class LMCounterPopulationTest(testing.TestCase):

--- a/synalinks/src/modules/module.py
+++ b/synalinks/src/modules/module.py
@@ -17,6 +17,7 @@ from synalinks.src.api_export import synalinks_export
 from synalinks.src.backend import is_trainable
 from synalinks.src.backend.common import global_state
 from synalinks.src.backend.common.name_scope import current_path
+from synalinks.src.backend.common.op_scope import current_op_scope
 from synalinks.src.hooks.hook_list import HookList
 from synalinks.src.metrics import Metric
 from synalinks.src.ops.operation import Operation
@@ -153,7 +154,7 @@ class Module(BackendModule, Operation, SynalinksSaveable):
         # Top-level invocation counters. Bumped only when this module is the
         # entry module of a `CallContext` — i.e., when it's the outermost
         # `__call__` in the stack. Nested calls leave these untouched.
-        # Phase routing follows the same `synalinks_op_scope` convention as
+        # Phase routing follows the same `op_scope` contextvar convention as
         # LanguageModel / EmbeddingModel.
         # Named `invocations` (not `calls`) to avoid colliding with the
         # LM/EM `cumulated_calls` semantic (= one provider call per increment).
@@ -720,7 +721,7 @@ class Module(BackendModule, Operation, SynalinksSaveable):
             elapsed_s = time.perf_counter() - module_call_ctx.start_time
             self.cumulated_invocations += 1
             self.cumulated_invocation_elapsed_s += elapsed_s
-            op_scope = global_state.get_global_attribute("synalinks_op_scope")
+            op_scope = current_op_scope()
             if op_scope in ("inference", "reward", "optimizer"):
                 setattr(
                     self,

--- a/synalinks/src/optimizers/omega.py
+++ b/synalinks/src/optimizers/omega.py
@@ -1,5 +1,6 @@
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
+import warnings
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
@@ -19,6 +20,7 @@ from synalinks.src.backend import Field
 from synalinks.src.backend import Trainable
 from synalinks.src.backend import out_mask_json
 from synalinks.src.backend.common import numpy as np
+from synalinks.src.modules.core.generator import Generator
 from synalinks.src.modules.core.input_module import Input
 from synalinks.src.modules.embedding_models import get as _get_em
 from synalinks.src.modules.ttc.chain_of_thought import ChainOfThought
@@ -287,6 +289,13 @@ class OMEGA(EvolutionaryOptimizer):
         reasoning_effort (string): Optional. The reasoning effort for the LM call
             between ['minimal', 'low', 'medium', 'high', 'disable', 'none', None].
             Default to None (no reasoning).
+        use_chain_of_thought (bool): Whether the mutation/crossover programs use
+            a `ChainOfThought` (which first writes a prompt-driven `thinking`
+            field, then the variable) or a plain `Generator` that emits the
+            variable directly. Disabling it gives a tighter, more bounded
+            generation (fewer tokens, no runaway reasoning) at the cost of the
+            explicit reasoning step -- useful for smaller/local models that ramble
+            under thinking. (Default to True).
         algorithm (str): The mechanism to use for the genetic algorithm
             between ['ga', 'dns']. This parameter is provided for ablation
             studies and shouldn't be modified. (Default to 'dns').
@@ -315,6 +324,7 @@ class OMEGA(EvolutionaryOptimizer):
         mutation_temperature=0.3,
         crossover_temperature=0.3,
         reasoning_effort=None,
+        use_chain_of_thought=True,
         merging_rate=0.02,
         algorithm="dns",
         selection="softmax",
@@ -340,6 +350,7 @@ class OMEGA(EvolutionaryOptimizer):
             instructions = ""
         self.instructions = instructions
         self.reasoning_effort = reasoning_effort
+        self.use_chain_of_thought = use_chain_of_thought
 
         # DNS-specific parameters
         self.embedding_model = _get_em(embedding_model)
@@ -362,6 +373,11 @@ class OMEGA(EvolutionaryOptimizer):
         # a cycle if `omega` loads before `programs.program` finishes.
         from synalinks.src.programs.program import Program
 
+        # `ChainOfThought` prepends a prompt-driven `thinking` field; a plain
+        # `Generator` emits the variable directly. The `in_mask` below keeps only
+        # the variable fields either way, so they are drop-in interchangeable.
+        module_cls = ChainOfThought if self.use_chain_of_thought else Generator
+
         for trainable_variable in trainable_variables:
             schema_id = id(trainable_variable.get_schema())
             mask = list(Trainable.keys())
@@ -371,7 +387,7 @@ class OMEGA(EvolutionaryOptimizer):
 
             if schema_id not in self.mutation_programs:
                 inputs = Input(data_model=MutationInputs)
-                outputs = await ChainOfThought(
+                outputs = await module_cls(
                     data_model=symbolic_variable,
                     language_model=self.language_model,
                     temperature=self.mutation_temperature,
@@ -392,7 +408,7 @@ class OMEGA(EvolutionaryOptimizer):
                             ]
                         )
                     ),
-                    name=f"mutation_cot_{schema_id}_" + self.name,
+                    name=f"mutation_module_{schema_id}_" + self.name,
                 )(inputs)
                 outputs = outputs.in_mask(mask=list(symbolic_variable.keys()))
                 program = Program(
@@ -405,7 +421,7 @@ class OMEGA(EvolutionaryOptimizer):
 
             if schema_id not in self.crossover_programs:
                 inputs = Input(data_model=CrossoverInputs)
-                outputs = await ChainOfThought(
+                outputs = await module_cls(
                     data_model=symbolic_variable,
                     language_model=self.language_model,
                     temperature=self.crossover_temperature,
@@ -426,7 +442,7 @@ class OMEGA(EvolutionaryOptimizer):
                             ]
                         )
                     ),
-                    name=f"crossover_cot_{schema_id}_" + self.name,
+                    name=f"crossover_module_{schema_id}_" + self.name,
                 )(inputs)
                 outputs = outputs.in_mask(mask=list(symbolic_variable.keys()))
                 program = Program(
@@ -483,7 +499,18 @@ class OMEGA(EvolutionaryOptimizer):
             current_variable=masked_variable,
         )
         program = self.mutation_programs[schema_id]
-        return await program(inputs, training=training)
+        # A failing LM call (timeout, rate limit, transient API error) must not
+        # kill fit(): warn and return None so the current best candidate is kept.
+        # assign_candidate / maybe_add_candidate treat a None candidate as a no-op.
+        try:
+            return await program(inputs, training=training)
+        except Exception as e:
+            warnings.warn(
+                f"OMEGA mutation at step {step} failed and was skipped "
+                f"(keeping the current best candidate): {type(e).__name__}: {e}",
+                stacklevel=2,
+            )
+            return None
 
     async def merge_candidate(
         self,
@@ -536,7 +563,18 @@ class OMEGA(EvolutionaryOptimizer):
             current_variable=current_variable,
         )
         program = self.crossover_programs[schema_id]
-        return await program(inputs, training=training)
+        # A failing LM call (timeout, rate limit, transient API error) must not
+        # kill fit(): warn and return None so the current best candidate is kept.
+        # assign_candidate / maybe_add_candidate treat a None candidate as a no-op.
+        try:
+            return await program(inputs, training=training)
+        except Exception as e:
+            warnings.warn(
+                f"OMEGA crossover at step {step} failed and was skipped "
+                f"(keeping the current best candidate): {type(e).__name__}: {e}",
+                stacklevel=2,
+            )
+            return None
 
     async def competition(self, candidates: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Apply Dominated Novelty Search (DNS) competition.
@@ -622,6 +660,7 @@ class OMEGA(EvolutionaryOptimizer):
             {
                 "instructions": self.instructions,
                 "reasoning_effort": self.reasoning_effort,
+                "use_chain_of_thought": self.use_chain_of_thought,
                 "k_nearest_fitter": self.k_nearest_fitter,
                 "algorithm": self.algorithm,
             }

--- a/synalinks/src/optimizers/omega_test.py
+++ b/synalinks/src/optimizers/omega_test.py
@@ -1,5 +1,6 @@
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from synalinks.src import testing
@@ -153,6 +154,107 @@ class OMEGATest(testing.TestCase):
         # Should filter out some candidates based on DNS
         self.assertGreater(len(result), 0)
         self.assertLessEqual(len(result), len(candidates))
+
+    def _make_trainable_variable(self):
+        """A minimal trainable variable for mutation/crossover tests."""
+        trainable_variable = JsonDataModel(
+            json={"instructions": "do the thing"},
+            schema={
+                "type": "object",
+                "properties": {"instructions": {"type": "string"}},
+            },
+        )
+        trainable_variable.description = "the variable to optimize"
+        return trainable_variable
+
+    def _make_batch(self):
+        """Minimal x / y / y_pred batches whose items expose `get_json`."""
+        x = [JsonDataModel(json={"q": "hi"}, schema={"type": "object"})]
+        y = [JsonDataModel(json={"a": "bye"}, schema={"type": "object"})]
+        y_pred = [JsonDataModel(json={"a": "yo"}, schema={"type": "object"})]
+        return x, y, y_pred
+
+    async def test_mutate_candidate_survives_lm_failure(self):
+        """A failing mutation LM call is skipped (returns None), not fatal."""
+        optimizer = OMEGA()
+        optimizer.set_program(SimpleNamespace(description="A test program"))
+
+        trainable_variable = self._make_trainable_variable()
+        schema_id = id(trainable_variable.get_schema())
+        optimizer.mutation_programs[schema_id] = AsyncMock(
+            side_effect=RuntimeError("litellm timeout after 600s"),
+        )
+
+        x, y, y_pred = self._make_batch()
+
+        with self.assertWarns(UserWarning):
+            result = await optimizer.mutate_candidate(
+                3,
+                trainable_variable,
+                {"instructions": "do the thing"},
+                x=x,
+                y=y,
+                y_pred=y_pred,
+                training=True,
+            )
+
+        self.assertIsNone(result)
+        optimizer.mutation_programs[schema_id].assert_awaited_once()
+
+    async def test_merge_candidate_survives_lm_failure(self):
+        """A failing crossover LM call is skipped (returns None), not fatal."""
+        optimizer = OMEGA()
+        optimizer.set_program(SimpleNamespace(description="A test program"))
+
+        trainable_variable = self._make_trainable_variable()
+        schema_id = id(trainable_variable.get_schema())
+        optimizer.crossover_programs[schema_id] = AsyncMock(
+            side_effect=RuntimeError("litellm timeout after 600s"),
+        )
+
+        x, y, y_pred = self._make_batch()
+
+        with self.assertWarns(UserWarning):
+            result = await optimizer.merge_candidate(
+                3,
+                trainable_variable,
+                {"instructions": "current"},
+                {"instructions": "other"},
+                x=x,
+                y=y,
+                y_pred=y_pred,
+                training=True,
+            )
+
+        self.assertIsNone(result)
+        optimizer.crossover_programs[schema_id].assert_awaited_once()
+
+    async def test_mutate_candidate_returns_program_output_on_success(self):
+        """On success the mutation program's output is returned unchanged."""
+        optimizer = OMEGA()
+        optimizer.set_program(SimpleNamespace(description="A test program"))
+
+        trainable_variable = self._make_trainable_variable()
+        schema_id = id(trainable_variable.get_schema())
+        expected = JsonDataModel(
+            json={"instructions": "improved"},
+            schema={"type": "object"},
+        )
+        optimizer.mutation_programs[schema_id] = AsyncMock(return_value=expected)
+
+        x, y, y_pred = self._make_batch()
+
+        result = await optimizer.mutate_candidate(
+            3,
+            trainable_variable,
+            {"instructions": "do the thing"},
+            x=x,
+            y=y,
+            y_pred=y_pred,
+            training=True,
+        )
+
+        self.assertIs(result, expected)
 
     async def test_on_epoch_end_sorts_and_selects_candidates_ga(self):
         """Test on_epoch_end sorts candidates and selects top ones (GA mode)."""

--- a/synalinks/src/trainers/trainer.py
+++ b/synalinks/src/trainers/trainer.py
@@ -14,8 +14,8 @@ from synalinks.src import metrics as metrics_module
 from synalinks.src import optimizers as optimizers_module
 from synalinks.src import rewards as rewards_module
 from synalinks.src import tree
-from synalinks.src.backend.common import global_state
 from synalinks.src.backend.common import numpy
+from synalinks.src.backend.common.op_scope import op_scope
 from synalinks.src.saving import serialization_lib
 from synalinks.src.trainers.compile_utils import CompileMetrics
 from synalinks.src.trainers.compile_utils import CompileReward
@@ -245,9 +245,7 @@ class Trainer:
         del x
         del training
         rewards = []
-        prev_scope = global_state.get_global_attribute("synalinks_op_scope")
-        global_state.set_global_attribute("synalinks_op_scope", "reward")
-        try:
+        with op_scope("reward"):
             if self._compile_reward is not None:
                 if not self._compile_reward.built:
                     self._compile_reward.build(y[0], y_pred[0])
@@ -267,8 +265,6 @@ class Trainer:
             if len(rewards) == 0:
                 rewards = [0.0]
             return rewards
-        finally:
-            global_state.set_global_attribute("synalinks_op_scope", prev_scope)
 
     def stateless_compute_reward(
         self,
@@ -921,9 +917,7 @@ class Trainer:
         if self.trainable_variables and isinstance(
             self.optimizer, optimizers_module.Optimizer
         ):
-            prev_scope = global_state.get_global_attribute("synalinks_op_scope")
-            global_state.set_global_attribute("synalinks_op_scope", "optimizer")
-            try:
+            with op_scope("optimizer"):
                 metrics = await self.optimizer.optimize(
                     step,
                     self.trainable_variables,
@@ -932,8 +926,6 @@ class Trainer:
                     val_x=val_x,
                     val_y=val_y,
                 )
-            finally:
-                global_state.set_global_attribute("synalinks_op_scope", prev_scope)
         else:
             warnings.warn("The program does not have any trainable variables.")
             y_pred = await self.predict_on_batch(val_x)
@@ -1008,19 +1000,14 @@ class Trainer:
         """
         # Tag this work as "inference" so LanguageModel / EmbeddingModel can
         # attribute token / latency / cost to the program's forward pass
-        # only. See synalinks.src.backend.common.global_state key
-        # `synalinks_op_scope` — value is one of "inference", "reward",
-        # "optimizer", or None.
-        prev_scope = global_state.get_global_attribute("synalinks_op_scope")
-        global_state.set_global_attribute("synalinks_op_scope", "inference")
-        try:
+        # only. See synalinks.src.backend.common.op_scope — the active phase
+        # is one of "inference", "reward", "optimizer", or None.
+        with op_scope("inference"):
             tasks = []
             for inputs in x:
                 tasks.append(self(inputs, training=training))
             y_pred = await asyncio.gather(*tasks)
             return y_pred
-        finally:
-            global_state.set_global_attribute("synalinks_op_scope", prev_scope)
 
     def get_compile_config(self):
         """Returns a serialized config with information for compiling the program.


### PR DESCRIPTION
## Summary

Extends operational metrics with reliability and latency signals, and fixes throughput under concurrency.

- **Phase routing → contextvar.** New `backend/common/op_scope.py` replaces the `synalinks_op_scope` global flag with a `contextvars`-based `op_scope` context manager. Concurrent LM/EM calls spawned inside `asyncio.gather`/greenlets now inherit the correct phase (`inference`/`reward`/`optimizer`) instead of being misattributed. The same module accrues per-phase wall-clock via a nesting stack (self-time only, so the optimizer phase isn't double-counted with the reward span it wraps).
- **Wall-clock throughput.** `Throughput`/`EmbeddingThroughput` (and per-phase variants) now divide by phase wall-clock instead of summed `elapsed_s`, so concurrent calls report real RPS rather than a deflated rate.
- **New metrics** across inference/reward/optimizer phases for both LM and EM:
  - `Avg*Latency` (mean per-call latency = `elapsed_s / calls`, concurrency-independent)
  - `Avg*PerCall` token averages (total / cached / cache-creation / reasoning)
  - `FailedCalls`, `FallbackActivations`, `ErrorRate` (reliability) — failures bump separate counters so error rate is observable even though they leave token/cost/latency counters untouched.
- **LanguageModel:** `reasoning_effort="disable"` now maps to ollama's `think=False` (no-op for opt-in providers); documented the value semantics.
- **OMEGA:** added `use_chain_of_thought` toggle (plain `Generator` vs `ChainOfThought` for mutation/crossover), and a failing mutation/crossover LM call now warns and keeps the current best candidate instead of crashing `fit()`.

## Test plan

- [x] `uv run pytest synalinks/src/metrics/lm_metrics_test.py synalinks/src/metrics/em_metrics_test.py` — 47 passed
- New tests cover wall-clock throughput vs summed-elapsed, latency, per-call averages, failure/error-rate metrics, and `op_scope` phase inheritance + nested self-time crediting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)