### PR TITLE
chore: bump synaops to >=0.2.1 and release 0.8.033

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "pydantic-monty",
   "pydotplus",
   "rich",
-  "synaops>=0.2.0",
+  "synaops>=0.2.1",
   "tenacity",
 ]
 

--- a/synalinks/src/version.py
+++ b/synalinks/src/version.py
@@ -3,7 +3,7 @@
 from synalinks.src.api_export import synalinks_export
 
 # Unique source of truth for the version number.
-__version__ = "0.8.032"
+__version__ = "0.8.033"
 
 
 @synalinks_export("synalinks.version")


### PR DESCRIPTION
## Summary

Follow-up to #59, which was merged one commit short — it landed at the `litellm` floor bump but **not** the final commit (`55b9ea4`). This re-lands it.

- `synaops>=0.2.0` → **`>=0.2.1`**: pins the patched native `in_mask_json`, which now drops unmatched arrays to match the Python fallback fixed in #59. Without this, `main`'s array-masking tests (`test_mask_in_array_drops_unmatched_array`) fail against the old `synaops`.
- Version **`0.8.032` → `0.8.033`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)