### PR TITLE
fix(rewards,metrics): scalarize empty reductions and skip None mask leaves

### DIFF
--- a/synalinks/src/metrics/accuracy_metrics.py
+++ b/synalinks/src/metrics/accuracy_metrics.py
@@ -98,20 +98,36 @@ class Accuracy(Metric):
 
         if self.in_mask or self.in_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
         if self.out_mask or self.out_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
 
@@ -315,20 +331,36 @@ class BinaryAccuracy(Accuracy):
 
         if self.in_mask or self.in_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
         if self.out_mask or self.out_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
 
@@ -498,20 +530,36 @@ class CategoricalAccuracy(Accuracy):
 
         if self.in_mask or self.in_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
         if self.out_mask or self.out_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
 

--- a/synalinks/src/metrics/f_score_metrics.py
+++ b/synalinks/src/metrics/f_score_metrics.py
@@ -122,20 +122,36 @@ class FBetaScore(Metric):
 
         if self.in_mask or self.in_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
         if self.out_mask or self.out_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
 
@@ -458,20 +474,36 @@ class BinaryFBetaScore(FBetaScore):
 
         if self.in_mask or self.in_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
         if self.out_mask or self.out_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
 
@@ -741,20 +773,36 @@ class CategoricalFBetaScore(FBetaScore):
 
         if self.in_mask or self.in_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
         if self.out_mask or self.out_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
 

--- a/synalinks/src/metrics/reduction_metrics.py
+++ b/synalinks/src/metrics/reduction_metrics.py
@@ -215,20 +215,36 @@ class MeanMetricWrapper(Mean):
         y_true = tree.map_structure(lambda x: ops.convert_to_json_data_model(x), y_true)
         if self.in_mask or self.in_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern),
+                lambda x: (
+                    x.in_mask(mask=self.in_mask, pattern=self.in_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
         if self.out_mask or self.out_mask_pattern:
             y_pred = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_pred,
             )
             y_true = tree.map_structure(
-                lambda x: x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern),
+                lambda x: (
+                    x.out_mask(mask=self.out_mask, pattern=self.out_mask_pattern)
+                    if x is not None
+                    else x
+                ),
                 y_true,
             )
         values = await self._fn(y_true, y_pred, **self._fn_kwargs)

--- a/synalinks/src/rewards/reward.py
+++ b/synalinks/src/rewards/reward.py
@@ -115,22 +115,34 @@ def apply_masks(
 
     if (in_mask or in_mask_pattern) and y_pred:
         y_pred = tree.map_structure(
-            lambda x: x.in_mask(mask=in_mask, pattern=in_mask_pattern),
+            lambda x: (
+                x.in_mask(mask=in_mask, pattern=in_mask_pattern) if x is not None else x
+            ),
             y_pred,
         )
     if (in_mask or in_mask_pattern) and y_true:
         y_true = tree.map_structure(
-            lambda x: x.in_mask(mask=in_mask, pattern=in_mask_pattern),
+            lambda x: (
+                x.in_mask(mask=in_mask, pattern=in_mask_pattern) if x is not None else x
+            ),
             y_true,
         )
     if (out_mask or out_mask_pattern) and y_pred:
         y_pred = tree.map_structure(
-            lambda x: x.out_mask(mask=out_mask, pattern=out_mask_pattern),
+            lambda x: (
+                x.out_mask(mask=out_mask, pattern=out_mask_pattern)
+                if x is not None
+                else x
+            ),
             y_pred,
         )
     if (out_mask or out_mask_pattern) and y_true:
         y_true = tree.map_structure(
-            lambda x: x.out_mask(mask=out_mask, pattern=out_mask_pattern),
+            lambda x: (
+                x.out_mask(mask=out_mask, pattern=out_mask_pattern)
+                if x is not None
+                else x
+            ),
             y_true,
         )
     return y_true, y_pred
@@ -176,6 +188,12 @@ def squeeze_or_expand_to_same_rank(x1, x2, expand_rank_1=True):
 
 
 def reduce_values(values, reduction="mean"):
+    # An empty batch carries no signal to reduce, so every reduction collapses
+    # to a scalar 0.0. This keeps downstream scalar consumers (trackers, tuner
+    # objectives) from ever receiving an empty list (the ``"none"`` branch) or
+    # hitting ``min``/``max``'s "zero-size array" error.
+    if hasattr(values, "__len__") and len(values) == 0:
+        return 0.0
     if reduction is None or reduction == "none":
         # Preserve the per-sample structure: scalars stay scalars, lists/
         # arrays are returned unreduced.

--- a/synalinks/src/rewards/reward_test.py
+++ b/synalinks/src/rewards/reward_test.py
@@ -1,6 +1,9 @@
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
 from synalinks.src import testing
+from synalinks.src import tree
+from synalinks.src.backend import DataModel
+from synalinks.src.rewards.reward import apply_masks
 from synalinks.src.rewards.reward import reduce_rewards
 from synalinks.src.rewards.reward import reduce_values
 
@@ -42,6 +45,51 @@ class ReduceValuesTest(testing.TestCase):
     def test_list_none_via_python_none(self):
         result = reduce_values([0.0, 1.0], None)
         self.assertEqual(list(result), [0.0, 1.0])
+
+    def test_empty_returns_zero_for_every_reduction(self):
+        # An empty batch has no signal: every reduction must collapse to a
+        # scalar 0.0. Regression: "none"/None returned the empty list and
+        # min/max raised "zero-size array to reduction operation", both of
+        # which break scalar consumers (e.g. a tuner objective expecting a
+        # float, not a list).
+        for reduction in ("mean", "sum", "min", "max", "none", None):
+            result = reduce_values([], reduction)
+            self.assertIsInstance(result, float)
+            self.assertEqual(result, 0.0)
+
+
+class ApplyMasksTest(testing.TestCase):
+    def test_skips_none_leaves(self):
+        # A batch can carry None leaves (e.g. a sample with no gold for a
+        # judge-only reward). Masking must skip them instead of calling
+        # ``None.in_mask`` / ``None.out_mask`` and raising AttributeError.
+        class Answer(DataModel):
+            answer: str
+            extra: str = ""
+
+        y_true = [Answer(answer="a", extra="x"), None]
+        y_pred = [Answer(answer="a", extra="y"), None]
+
+        masked_true, masked_pred = apply_masks(y_true, y_pred, in_mask=["answer"])
+        to_json = lambda x: None if x is None else x.get_json()
+        self.assertEqual(
+            tree.map_structure(to_json, masked_pred), [{"answer": "a"}, None]
+        )
+        self.assertEqual(
+            tree.map_structure(to_json, masked_true), [{"answer": "a"}, None]
+        )
+
+    def test_skips_none_leaves_out_mask(self):
+        class Answer(DataModel):
+            answer: str
+            extra: str = ""
+
+        y_pred = [Answer(answer="a", extra="y"), None]
+        _, masked_pred = apply_masks(None, y_pred, out_mask=["extra"])
+        to_json = lambda x: None if x is None else x.get_json()
+        self.assertEqual(
+            tree.map_structure(to_json, masked_pred), [{"answer": "a"}, None]
+        )
 
 
 class ReduceRewardsTest(testing.TestCase):


### PR DESCRIPTION
## Summary

Two robustness fixes for degenerate reward/metric inputs that surfaced as a *"metric should be a float, not a list"* error from the keras-tuner objective when a `rubrics_as_judge` reward hit an empty/None batch.

### 1. `reduce_values`: empty batch → scalar `0.0` for every reduction
An empty batch carries no signal, so it should collapse to a scalar. Previously:
- `reduction="none"`/`None` returned the **empty list** `[]` — which scalar consumers (trackers, tuner objectives) reject as *"should be a float, not a list."*
- `reduction="min"`/`"max"` raised `ValueError: zero-size array to reduction operation minimum which has no identity`.

Now an empty input returns `0.0` for `mean`/`sum`/`min`/`max`/`none`/`None` alike. (`reduce_rewards` already did this.)

### 2. None-safe field masking in rewards & metrics
`apply_masks` (rewards) and the metric mask lambdas (`Mean`/`Sum` wrappers, `Accuracy`, and the F-score/precision/recall family) called `x.in_mask(...)` / `x.out_mask(...)` for every leaf under `tree.map_structure`. A `None` leaf — e.g. a sample with no gold for a judge-only reward — raised `AttributeError`. Each call site now guards with `if x is not None` and passes the `None` leaf through untouched.

## Tests
- `reduce_values([], r) == 0.0` for every reduction `r`.
- `apply_masks` skips `None` leaves for both `in_mask` and `out_mask`.
- Full `rewards/` + `metrics/` suites pass (181 passed) and `ruff` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)