### PR TITLE
ci: drop Windows from the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.11", "3.12", "3.13"]
 
     defaults:
@@ -37,9 +37,6 @@ jobs:
       - name: Install graphviz (macOS)
         if: runner.os == 'macOS'
         run: brew install graphviz
-      - name: Install graphviz (Windows)
-        if: runner.os == 'Windows'
-        run: choco install graphviz --no-progress -y
       - name: Install Synalinks
         run: ./shell/install.sh
       - name: Install pytest


### PR DESCRIPTION
## Summary

Remove `windows-latest` from the Tests workflow matrix (and the Windows-only graphviz install step). Coverage remains on **ubuntu-latest** and **macos-latest** across Python 3.11/3.12/3.13.

## Why

- **Flaky:** the ladybug graph-DB adapter's native `vector` extension intermittently fails to install/load on Windows cells, so `CREATE_VECTOR_INDEX` is undefined and `ladybug_adapter_test` hard-fails (e.g. windows-latest/3.13 on a recent run), while every Linux/macOS cell passes.
- **Slow:** the Windows jobs take ~25m vs ~5m on Linux/macOS.
- GitHub is also mid-migrating the Windows runners (`windows-latest → windows-2025-vs2026`), adding more churn.

If first-class Windows support is wanted later, the right fix is to pin/cache the ladybug extensions (or skip the vector-index tests when the extension didn't load) rather than keep a flaky matrix cell red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)