### PR TITLE
fix: honor rate-limit Retry-After in LM/embedding retries (0.8.37)

### DIFF
--- a/synalinks/src/modules/embedding_models/embedding_model.py
+++ b/synalinks/src/modules/embedding_models/embedding_model.py
@@ -9,7 +9,6 @@ import litellm
 from tenacity import before_sleep_log
 from tenacity import retry
 from tenacity import stop_after_attempt
-from tenacity import wait_exponential
 
 from synalinks.src.api_export import synalinks_export
 from synalinks.src.backend import Embeddings
@@ -17,6 +16,7 @@ from synalinks.src.backend import JsonDataModel
 from synalinks.src.backend.common.op_scope import current_op_scope
 from synalinks.src.modules.module import Module
 from synalinks.src.saving import serialization_lib
+from synalinks.src.utils.retry_utils import rate_limit_aware_wait
 
 litellm.disable_aiohttp_transport = True
 
@@ -163,6 +163,8 @@ class EmbeddingModel(Module):
         model (str): The model to use.
         api_base (str): Optional. The endpoint to use.
         retry (int): Optional. The number of retry.
+        retry_max_wait (int): Optional. Max seconds to wait between retries when a
+            rate-limit `Retry-After` header is honored (default to 60).
         fallback (EmbeddingModel): Optional. The embedding model to fallback
             if anything is wrong.
         caching (bool): Enables caching (Default to True).
@@ -180,6 +182,7 @@ class EmbeddingModel(Module):
         model=None,
         api_base=None,
         retry=5,
+        retry_max_wait=60,
         fallback=None,
         caching=True,
         name=None,
@@ -203,6 +206,7 @@ class EmbeddingModel(Module):
         else:
             self.api_base = api_base
         self.retry = retry
+        self.retry_max_wait = retry_max_wait
         if fallback is not None:
             # Lazy import: `get` lives in the package __init__ which imports
             # this file at load time.
@@ -299,7 +303,9 @@ class EmbeddingModel(Module):
 
         @retry(
             stop=stop_after_attempt(self.retry),
-            wait=wait_exponential(multiplier=1, min=1, max=10),
+            # Honor a rate-limit `Retry-After` header (e.g. Azure OpenAI TPM
+            # throttling); fall back to exponential backoff for other errors.
+            wait=rate_limit_aware_wait(max_wait=self.retry_max_wait),
             before_sleep=before_sleep_log(logger, logging.WARNING),
             reraise=True,
         )
@@ -373,6 +379,7 @@ class EmbeddingModel(Module):
             "model": self.model,
             "api_base": self.api_base,
             "retry": self.retry,
+            "retry_max_wait": self.retry_max_wait,
             "name": self.name,
             "description": self.description,
             **self.default_kwargs,

--- a/synalinks/src/modules/language_models/language_model.py
+++ b/synalinks/src/modules/language_models/language_model.py
@@ -11,7 +11,6 @@ import orjson
 from tenacity import before_sleep_log
 from tenacity import retry
 from tenacity import stop_after_attempt
-from tenacity import wait_exponential
 
 from synalinks.src.api_export import synalinks_export
 from synalinks.src.backend import ChatMessage
@@ -23,6 +22,7 @@ from synalinks.src.modules.core.tool import Tool
 from synalinks.src.modules.module import Module
 from synalinks.src.saving import serialization_lib
 from synalinks.src.utils.nlp_utils import shorten_text
+from synalinks.src.utils.retry_utils import rate_limit_aware_wait
 
 litellm.drop_params = True
 litellm.disable_aiohttp_transport = True
@@ -460,6 +460,8 @@ class LanguageModel(Module):
         api_base (str): Optional. The endpoint to use.
         timeout (int): Optional. The timeout value in seconds (Default to 600).
         retry (int): Optional. The number of retry (default to 5).
+        retry_max_wait (int): Optional. Max seconds to wait between retries when a
+            rate-limit `Retry-After` header is honored (default to 60).
         fallback (LanguageModel): Optional. The language model to fallback
             if anything is wrong.
         caching (bool): Optional. Enable caching of LM calls (Default to False).
@@ -479,6 +481,7 @@ class LanguageModel(Module):
         api_base=None,
         timeout=600,
         retry=5,
+        retry_max_wait=60,
         fallback=None,
         caching=False,
         name=None,
@@ -531,6 +534,7 @@ class LanguageModel(Module):
             )
         self.timeout = timeout
         self.retry = retry
+        self.retry_max_wait = retry_max_wait
         self.caching = caching
         self.default_kwargs = default_kwargs
         self.cumulated_cost = 0.0
@@ -873,7 +877,9 @@ class LanguageModel(Module):
 
         @retry(
             stop=stop_after_attempt(self.retry),
-            wait=wait_exponential(multiplier=1, min=1, max=10),
+            # Honor a rate-limit `Retry-After` header (e.g. Azure OpenAI TPM
+            # throttling); fall back to exponential backoff for other errors.
+            wait=rate_limit_aware_wait(max_wait=self.retry_max_wait),
             before_sleep=before_sleep_log(logger, logging.WARNING),
             reraise=True,
         )
@@ -1006,6 +1012,7 @@ class LanguageModel(Module):
             "api_base": self.api_base,
             "timeout": self.timeout,
             "retry": self.retry,
+            "retry_max_wait": self.retry_max_wait,
             "caching": self.caching,
             "name": self.name,
             "description": self.description,

--- a/synalinks/src/utils/retry_utils.py
+++ b/synalinks/src/utils/retry_utils.py
@@ -1,0 +1,55 @@
+"""Retry helpers shared by the language- and embedding-model wrappers.
+
+The model wrappers retry failed `litellm` calls with tenacity. Plain exponential
+backoff gives up too quickly under sustained provider rate limiting (e.g. a small
+Azure OpenAI TPM quota), so these helpers honor the server-instructed
+``Retry-After`` delay on 429s and only fall back to exponential backoff for other
+errors.
+"""
+
+from tenacity import wait_exponential
+
+
+def retry_after_seconds(exc):
+    """Server-instructed retry delay (seconds) for a rate-limit error.
+
+    Reads the standard ``Retry-After`` header that providers (OpenAI, Azure
+    OpenAI, Anthropic, ...) attach to a 429 response, falling back to the
+    ``retry_after`` attribute litellm/openai sometimes set on the exception.
+    Returns ``None`` when absent or unparseable (so the caller uses exponential
+    backoff instead). ``Retry-After`` given as a delay in seconds is honored;
+    the HTTP-date form is treated as unparseable and falls back to backoff.
+    """
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None) or {}
+    value = headers.get("retry-after") or headers.get("Retry-After")
+    if value is None:
+        value = getattr(exc, "retry_after", None)
+    if value is None:
+        return None
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def rate_limit_aware_wait(max_wait=60.0):
+    """A tenacity ``wait`` that honors a rate-limit ``Retry-After`` header.
+
+    On a 429 carrying ``Retry-After`` it waits exactly that long (capped at
+    ``max_wait`` so a hostile/huge value can't hang the call); for every other
+    error it falls back to the previous exponential backoff. Honoring the
+    server-instructed delay is what lets a run ride out sustained throttling
+    instead of exhausting short retries.
+    """
+    fallback = wait_exponential(multiplier=1, min=1, max=10)
+
+    def _wait(retry_state):
+        outcome = getattr(retry_state, "outcome", None)
+        exc = outcome.exception() if outcome is not None else None
+        retry_after = retry_after_seconds(exc) if exc is not None else None
+        if retry_after is not None:
+            return min(retry_after, max_wait)
+        return fallback(retry_state)
+
+    return _wait

--- a/synalinks/src/utils/retry_utils_test.py
+++ b/synalinks/src/utils/retry_utils_test.py
@@ -1,0 +1,65 @@
+# License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
+
+import types
+
+from synalinks.src import testing
+from synalinks.src.utils import retry_utils
+
+
+class _Response:
+    def __init__(self, headers):
+        self.headers = headers
+
+
+class _RateLimitError(Exception):
+    def __init__(self, headers=None, retry_after=None):
+        self.response = _Response(headers) if headers is not None else None
+        if retry_after is not None:
+            self.retry_after = retry_after
+
+
+def _retry_state(exc, attempt_number=1):
+    """Minimal stand-in for a tenacity RetryCallState carrying a failed outcome."""
+    outcome = types.SimpleNamespace(exception=lambda: exc, failed=True)
+    return types.SimpleNamespace(outcome=outcome, attempt_number=attempt_number)
+
+
+class RetryAfterSecondsTest(testing.TestCase):
+    def test_reads_retry_after_header(self):
+        exc = _RateLimitError(headers={"retry-after": "30"})
+        self.assertEqual(retry_utils.retry_after_seconds(exc), 30.0)
+
+    def test_reads_capitalized_header(self):
+        exc = _RateLimitError(headers={"Retry-After": "12"})
+        self.assertEqual(retry_utils.retry_after_seconds(exc), 12.0)
+
+    def test_falls_back_to_attribute(self):
+        exc = _RateLimitError(retry_after="7")
+        self.assertEqual(retry_utils.retry_after_seconds(exc), 7.0)
+
+    def test_none_when_absent(self):
+        self.assertIsNone(retry_utils.retry_after_seconds(_RateLimitError()))
+
+    def test_none_when_unparseable(self):
+        # HTTP-date form isn't a plain seconds value -> fall back to backoff.
+        exc = _RateLimitError(headers={"retry-after": "Wed, 21 Oct 2026 07:28:00 GMT"})
+        self.assertIsNone(retry_utils.retry_after_seconds(exc))
+
+
+class RateLimitAwareWaitTest(testing.TestCase):
+    def test_honors_retry_after(self):
+        wait = retry_utils.rate_limit_aware_wait(max_wait=60)
+        exc = _RateLimitError(headers={"retry-after": "30"})
+        self.assertEqual(wait(_retry_state(exc)), 30.0)
+
+    def test_caps_at_max_wait(self):
+        wait = retry_utils.rate_limit_aware_wait(max_wait=60)
+        exc = _RateLimitError(headers={"retry-after": "200"})
+        self.assertEqual(wait(_retry_state(exc)), 60)
+
+    def test_falls_back_to_exponential_without_header(self):
+        wait = retry_utils.rate_limit_aware_wait(max_wait=60)
+        # No Retry-After -> exponential backoff, which grows with the attempt.
+        first = wait(_retry_state(_RateLimitError(), attempt_number=1))
+        later = wait(_retry_state(_RateLimitError(), attempt_number=3))
+        self.assertGreater(later, first)

--- a/synalinks/src/version.py
+++ b/synalinks/src/version.py
@@ -3,7 +3,7 @@
 from synalinks.src.api_export import synalinks_export
 
 # Unique source of truth for the version number.
-__version__ = "0.8.036"
+__version__ = "0.8.037"
 
 
 @synalinks_export("synalinks.version")


### PR DESCRIPTION
Plain exponential backoff (capped at 10s, 5 attempts) gave up too quickly under sustained provider rate limiting (e.g. a small Azure OpenAI TPM quota), failing runs with 'All retries failed'. Add shared retry_utils.rate_limit_aware_wait, which waits the server-instructed Retry-After delay on 429s (capped at a new retry_max_wait, default 60s) and falls back to exponential backoff otherwise. Wire it into both LanguageModel and EmbeddingModel; retry_max_wait is a constructor arg and serialized in get_config. Bump version to 0.8.037.