### PR TITLE
fix: isolate module call-context per asyncio task (#63)

### DIFF
--- a/synalinks/src/modules/module.py
+++ b/synalinks/src/modules/module.py
@@ -3,6 +3,7 @@
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
 import collections
+import contextvars
 import inspect
 import time
 import uuid
@@ -15,7 +16,6 @@ from synalinks.src import tree
 from synalinks.src import utils
 from synalinks.src.api_export import synalinks_export
 from synalinks.src.backend import is_trainable
-from synalinks.src.backend.common import global_state
 from synalinks.src.backend.common.name_scope import current_path
 from synalinks.src.backend.common.op_scope import current_op_scope
 from synalinks.src.hooks.hook_list import HookList
@@ -33,6 +33,18 @@ else:
     raise RuntimeError(
         f"Backend '{backend.backend()}' must implement a module mixin class."
     )
+
+
+# Per-call execution context (`call_id`, `parent_call_id`, `training`,
+# `entry_module`). Stored in a `contextvars.ContextVar` rather than the
+# `threading.local` global state: an asyncio event loop runs many coroutines on
+# a single OS thread, so a thread-local context is shared — and corrupted —
+# between modules awaited concurrently, e.g. `asyncio.gather(modA(x), modB(x))`
+# or parallel branches in a `Program`. A `ContextVar` is copied into each
+# `asyncio.Task`/greenlet at creation, so concurrent calls each get an isolated
+# context while nested `await`s within a single call keep sharing it. This
+# mirrors the `op_scope` ContextVar (see `backend/common/op_scope.py`).
+_CALL_CONTEXT = contextvars.ContextVar("synalinks_call_ctx", default=None)
 
 
 @synalinks_export(["synalinks.Module", "synalinks.modules.Module"])
@@ -531,7 +543,7 @@ class Module(BackendModule, Operation, SynalinksSaveable):
         self._check_super_called()
         self._called = True
 
-        call_context = self._get_call_context()
+        call_context, call_ctx_token = self._enter_call_context()
 
         parent_call_id = call_context.call_id if call_context.call_id else None
 
@@ -625,7 +637,7 @@ class Module(BackendModule, Operation, SynalinksSaveable):
             raise e
         finally:
             # Destroy call context if we created it
-            self._maybe_reset_call_context()
+            self._maybe_reset_call_context(call_ctx_token)
         if self._hooks:
             self._hooks.on_call_end(
                 call_id=call_id,
@@ -702,22 +714,49 @@ class Module(BackendModule, Operation, SynalinksSaveable):
         )
         return inputs
 
-    def _get_call_context(self):
-        """Returns currently active `CallContext`."""
-        module_call_ctx = global_state.get_global_attribute("current_call_ctx")
+    def _enter_call_context(self):
+        """Returns the active `CallContext`, creating one if this is the entry
+        (outermost) module call.
+
+        The context lives in the `_CALL_CONTEXT` ContextVar, so concurrent
+        calls awaited on one event loop thread each get an isolated context
+        (see the note on `_CALL_CONTEXT`).
+
+        Returns a `(call_context, token)` tuple. `token` is the
+        `ContextVar.reset` token when this call created the context (and is
+        therefore the entry module); it is `None` when reusing a parent's
+        context. Pass the token to `_maybe_reset_call_context` to tear it down.
+        """
+        module_call_ctx = _CALL_CONTEXT.get()
         if module_call_ctx is None:
             # Enter new call context.
             module_call_ctx = CallContext(entry_module=self)
-            global_state.set_global_attribute("current_call_ctx", module_call_ctx)
+            token = _CALL_CONTEXT.set(module_call_ctx)
             self._clear_rewards()
-        return module_call_ctx
+            return module_call_ctx, token
+        return module_call_ctx, None
 
-    def _maybe_reset_call_context(self):
-        module_call_ctx = global_state.get_global_attribute("current_call_ctx")
-        if module_call_ctx is None:
-            global_state.set_global_attribute("current_call_ctx", None)
+    def _get_call_context(self):
+        """Returns the currently active `CallContext`, or `None`.
+
+        Read-only peek used by hooks/monitoring; unlike `_enter_call_context`
+        it never creates a context.
+        """
+        return _CALL_CONTEXT.get()
+
+    def _maybe_reset_call_context(self, token):
+        """Tear down the `CallContext` created by this call's
+        `_enter_call_context`.
+
+        A no-op for nested calls (`token is None`), which reuse the entry
+        module's context. When this call is the entry module, it accumulates
+        the invocation metrics and restores the ContextVar to its previous
+        (`None`) state via `token`.
+        """
+        if token is None:
             return
-        if module_call_ctx.entry_module is self:
+        module_call_ctx = _CALL_CONTEXT.get()
+        if module_call_ctx is not None and module_call_ctx.entry_module is self:
             elapsed_s = time.perf_counter() - module_call_ctx.start_time
             self.cumulated_invocations += 1
             self.cumulated_invocation_elapsed_s += elapsed_s
@@ -734,7 +773,7 @@ class Module(BackendModule, Operation, SynalinksSaveable):
                     getattr(self, f"{op_scope}_cumulated_invocation_elapsed_s")
                     + elapsed_s,
                 )
-            global_state.set_global_attribute("current_call_ctx", None)
+        _CALL_CONTEXT.reset(token)
 
     def _flatten_modules(self, include_self=True, recursive=True):
         modules = []

--- a/synalinks/src/modules/module_test.py
+++ b/synalinks/src/modules/module_test.py
@@ -2,6 +2,8 @@
 # Original authors: François Chollet et al. (Keras Team)
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
+import asyncio
+
 from synalinks.src import backend
 from synalinks.src import modules
 from synalinks.src import testing
@@ -93,3 +95,53 @@ class ModuleTest(testing.TestCase):
         self.assertEqual(
             out["2"].get_schema(), backend.standardize_schema(Query.get_schema())
         )
+
+    async def test_concurrent_calls_have_isolated_call_context(self):
+        # Regression test for GH#63: the per-call `CallContext` used to live in
+        # `threading.local` global state. An asyncio event loop runs many
+        # coroutines on one thread, so two modules awaited concurrently
+        # (`asyncio.gather`) shared — and corrupted — a single context between
+        # `await` points: `call_id`/`parent_call_id` were overwritten and the
+        # first call to return detached the other's still-running context.
+        # The context now lives in a `contextvars.ContextVar`, so each
+        # concurrent call keeps a private, stable context for its lifetime.
+
+        class Query(backend.DataModel):
+            x: int
+
+        class CtxProbe(modules.Module):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.observed = {}
+
+            async def call(self, inputs, training=False):
+                ctx_before = self._get_call_context()
+                id_before = ctx_before.call_id if ctx_before else None
+                # Yield to the sibling coroutine so a shared context would be
+                # clobbered here.
+                await asyncio.sleep(0.02)
+                ctx_after = self._get_call_context()
+                id_after = ctx_after.call_id if ctx_after else None
+                self.observed = {
+                    "same_ctx_object": ctx_before is ctx_after,
+                    "call_id_stable": id_before == id_after,
+                    "training_seen": training,
+                }
+                return inputs
+
+            async def compute_output_spec(self, inputs, training=False):
+                return inputs
+
+        a = CtxProbe(name="a")
+        b = CtxProbe(name="b")
+        await asyncio.gather(
+            a(Query(x=1).to_json_data_model(), training=True),
+            b(Query(x=2).to_json_data_model(), training=False),
+        )
+
+        for probe in (a, b):
+            self.assertTrue(probe.observed["same_ctx_object"])
+            self.assertTrue(probe.observed["call_id_stable"])
+        # `training` is captured per-call and must not leak between siblings.
+        self.assertTrue(a.observed["training_seen"])
+        self.assertFalse(b.observed["training_seen"])

--- a/synalinks/src/version.py
+++ b/synalinks/src/version.py
@@ -3,7 +3,7 @@
 from synalinks.src.api_export import synalinks_export
 
 # Unique source of truth for the version number.
-__version__ = "0.8.037"
+__version__ = "0.8.038"
 
 
 @synalinks_export("synalinks.version")


### PR DESCRIPTION
## Problem

Fixes #63.

`Module`'s per-call `CallContext` (`call_id`, `parent_call_id`, `training`, `entry_module`) lived in `threading.local` global state. An asyncio event loop runs many coroutines on **one** OS thread, so two modules awaited concurrently — `await asyncio.gather(modA(x), modB(x))`, or parallel branches in a `Program` — read and overwrote the **same** `CallContext` between `await` points. This corrupted:

1. **`call_id` / `parent_call_id`** → wrong call-graph / observability traces (a child recorded under the wrong parent).
2. **context lifetime** → when the first concurrent call returned, the shared context was reset to `None` while the *other* call was still running, detaching its subtree.

Instantiating distinct module instances (a "pool") did not help: the corrupt state lived in thread-global state, not on the instance.

## Fix

Move the call context off `threading.local` onto a `contextvars.ContextVar` (`_CALL_CONTEXT`). A `ContextVar` is copied into each `asyncio.Task`/greenlet at creation, so concurrent calls each get an isolated context while nested `await`s within a single call keep sharing it. This preserves single-thread behaviour while making concurrent `await`s correct, and mirrors the existing `op_scope` ContextVar (`backend/common/op_scope.py`). The project's async infra already copies/back-propagates contextvars across its nested-run boundaries.

- `_get_call_context()` is now a read-only peek (used by hooks/monitoring); it never creates a context.
- New `_enter_call_context()` creates the context on the entry module and returns a `(ctx, token)` pair.
- `_maybe_reset_call_context(token)` uses token-based `ContextVar.reset` — same pattern as `op_scope`.
- Removed the now-unused `global_state` import.

## Verification

- The issue's exact reproduction now yields the expected `same_ctx_object: True`, `call_id_stable: True`, with correct per-call `training`.
- Added regression test `test_concurrent_calls_have_isolated_call_context` in `module_test.py`.
- Version bumped `0.8.037` → `0.8.038`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)