### PR TITLE
fix(generator): don't splat a contained chat message into a strict ChatMessage

### DIFF
--- a/synalinks/src/modules/core/generator.py
+++ b/synalinks/src/modules/core/generator.py
@@ -12,7 +12,6 @@ from synalinks.src.backend import ChatRole
 from synalinks.src.backend import Instructions
 from synalinks.src.backend import Prediction
 from synalinks.src.backend import SymbolicDataModel
-from synalinks.src.backend import is_chat_message
 from synalinks.src.backend import is_chat_messages
 from synalinks.src.backend import is_strictly_chat_message
 from synalinks.src.backend import is_strictly_chat_messages
@@ -398,8 +397,13 @@ class Generator(Module):
                 )
             messages.extend(msgs)
             return ChatMessages(messages=messages)
-        if is_chat_message(inputs):
-            return ChatMessages(messages=[system_message, inputs.get_json()])
+        # NB: a strictly-chat-message input is already handled by the
+        # is_strictly_chat_message early-return above. Anything that only
+        # *contains* a chat message here also carries extra fields (a reward's
+        # `gold_`-prefixed reference, inputs concatenated by an upstream
+        # generator, ...). Splatting the whole dict into a single ChatMessage
+        # would trip its `extra="forbid"`, so it falls through to be rendered as
+        # input data below.
         user_message = ChatMessage(
             role="user", 
             content=f"<input>\n{inputs.get_json()}\n</input>\n<output>\n",

--- a/synalinks/src/modules/core/generator_test.py
+++ b/synalinks/src/modules/core/generator_test.py
@@ -377,6 +377,43 @@ class GeneratorModuleTest(testing.TestCase):
         self.assertIn("just-a-question", rendered)
         self.assertNotIn("trailing-output", rendered)
 
+    async def test_format_messages_contained_chat_message_with_extra_fields(self):
+        """An input that only *contains* a chat message but carries extra sibling
+        fields (and no `messages` list) must not be splatted into a single strict
+        ChatMessage — that trips ChatMessage's `extra="forbid"`.
+
+        Mirrors `LMAsJudge`, which concatenates a `gold_`-prefixed reference with
+        the prediction: the merged model is `{gold_role, gold_content, role,
+        content}` — chat-message-shaped, but not strictly a chat message. It is
+        rendered as input data (system + user turn), not sent as a chat message.
+        """
+
+        language_model = LanguageModel(model="ollama/mistral")
+        generator = Generator(
+            language_model=language_model,
+            instructions="be helpful",
+        )
+
+        merged = await ops.concat(
+            await ops.prefix(
+                ChatMessage(role="assistant", content="gold-answer"),
+                prefix="gold",
+            ),
+            ChatMessage(role="assistant", content="predicted-answer"),
+        )
+
+        # Must not raise (previously: ValidationError — extra inputs forbidden).
+        msgs = generator.format_messages(merged).get("messages")
+        roles = [
+            m["role"].value if hasattr(m["role"], "value") else m["role"] for m in msgs
+        ]
+        rendered = " ".join(str(m["content"]) for m in msgs)
+
+        self.assertEqual(roles, ["system", "user"])
+        # Both the prediction and the gold reference survive into the prompt.
+        self.assertIn("predicted-answer", rendered)
+        self.assertIn("gold-answer", rendered)
+
     def test_format_message_with_instructions(self):
         class Query(DataModel):
             query: str

--- a/synalinks/src/version.py
+++ b/synalinks/src/version.py
@@ -3,7 +3,7 @@
 from synalinks.src.api_export import synalinks_export
 
 # Unique source of truth for the version number.
-__version__ = "0.9.000"
+__version__ = "0.9.001"
 
 
 @synalinks_export("synalinks.version")


### PR DESCRIPTION
## Problem

Every `lm_as_judge`-scored evaluation crashes during reward computation with:

```
pydantic_core.ValidationError: validation errors for ChatMessages
  messages.gold_role     Extra inputs are not permitted ('assistant')
  messages.gold_content  Extra inputs are not permitted (...)
  messages.messages      Extra inputs are not permitted ([...])
```

## Root cause

`Generator.format_messages` has a loose branch:

```python
if is_chat_message(inputs):                      # containment check
    return ChatMessages(messages=[system_message, inputs.get_json()])
```

`is_chat_message` is a *containment* check, so it matches any input that merely **contains** a `ChatMessage` (i.e. has a `ChatRole`-typed `role` + `content`) even when it carries extra sibling fields. `LMAsJudge` builds exactly such an input — it prefixes the gold reference (`gold_role`, `gold_content`) and concatenates it with the prediction (which, with `return_inputs`, also carries the conversation `messages`). Splatting that whole dict into a single `ChatMessage` trips its `extra="forbid"` on the `gold_*` / `messages` keys, so the trial dies and the run hits the consecutive-failure limit.

## Fix

A genuine chat message is already handled by the `is_strictly_chat_message` early-return at the top of `format_messages`, so the loose `is_chat_message` branch only ever fired for *contains-plus-extras* inputs — for which the correct behavior is to render the object as input data, not send it as a chat message. Drop the branch and let those inputs fall through to the existing `<input>…</input>` rendering path (which preserves the gold reference, the prediction, and the conversation in the judge prompt). Removes the now-unused `is_chat_message` import.

## Test

Adds `test_format_messages_contained_chat_message_with_extra_fields`, which reconstructs the `LMAsJudge` shape (`prefix(gold)` + prediction). It **fails on `main`** with the exact `extra_forbidden` `ValidationError` and passes with the fix. Full `generator_test.py` suite (18), `self_critique_test.py`, and `lm_as_judge_test.py` pass.

Bumps version to `0.9.001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)