### PR TITLE
fix(metrics): ragged state accumulation and unmatched-leaf scoring

### DIFF
--- a/synalinks/src/metrics/accuracy_metrics.py
+++ b/synalinks/src/metrics/accuracy_metrics.py
@@ -1,5 +1,6 @@
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
+from itertools import zip_longest
 from typing import List
 from typing import Optional
 
@@ -10,6 +11,7 @@ from synalinks.src.api_export import synalinks_export
 from synalinks.src.backend import DataModel
 from synalinks.src.backend.common import numpy as np
 from synalinks.src.metrics.metric import Metric
+from synalinks.src.metrics.metric import ragged_add
 from synalinks.src.utils import nlp_utils
 
 
@@ -141,7 +143,11 @@ class Accuracy(Metric):
         correct = []
         total = []
         intermediate_weights = []
-        for yt, yp in zip(y_true, y_pred):
+        # zip_longest, not zip: a prediction with fewer/more leaves than the
+        # gold must be scored against every leaf — plain zip would silently
+        # drop the unmatched ones and inflate the score. The "" fill has no
+        # tokens, so an unmatched leaf scores 0 over the other side's tokens.
+        for yt, yp in zip_longest(y_true, y_pred, fillvalue=""):
             y_true_tokens = nlp_utils.normalize_and_tokenize(str(yt))
             y_pred_tokens = nlp_utils.normalize_and_tokenize(str(yp))
             common_tokens = set(y_true_tokens) & set(y_pred_tokens)
@@ -156,15 +162,15 @@ class Accuracy(Metric):
 
         current_correct = self.state.get("correct")
         if current_correct:
-            correct = np.add(current_correct, correct)
+            correct = ragged_add(current_correct, correct)
 
         current_total = self.state.get("total")
         if current_total:
-            total = np.add(current_total, total)
+            total = ragged_add(current_total, total)
 
         current_intermediate_weights = self.state.get("intermediate_weights")
         if current_intermediate_weights:
-            intermediate_weights = np.add(
+            intermediate_weights = ragged_add(
                 current_intermediate_weights, intermediate_weights
             )
 
@@ -392,26 +398,34 @@ class BinaryAccuracy(Accuracy):
         y_true = np.convert_to_tensor(y_true)
         y_pred = np.convert_to_tensor(y_pred)
 
+        # zip_longest, not zip: a structure mismatch between pred and gold
+        # (variable-length arrays) must count the unmatched leaves as wrong,
+        # not silently drop them. The None fill never equals a 0.0/1.0 leaf.
+        y_true_leaves = y_true.tolist()
+        y_pred_leaves = y_pred.tolist()
+        size = max(len(y_true_leaves), len(y_pred_leaves))
         correct = np.convert_to_tensor(
             [
                 1.0 if yt == yp else 0.0
-                for yt, yp in zip(y_true.tolist(), y_pred.tolist())
+                for yt, yp in zip_longest(y_true_leaves, y_pred_leaves)
             ]
         )
-        total = np.convert_to_tensor([1.0] * len(y_true.tolist()))
-        intermediate_weights = y_true
+        total = np.convert_to_tensor([1.0] * size)
+        intermediate_weights = np.convert_to_tensor(
+            y_true_leaves + [0.0] * (size - len(y_true_leaves))
+        )
 
         current_correct = self.state.get("correct")
         if current_correct:
-            correct = np.add(current_correct, correct)
+            correct = ragged_add(current_correct, correct)
 
         current_total = self.state.get("total")
         if current_total:
-            total = np.add(current_total, total)
+            total = ragged_add(current_total, total)
 
         current_intermediate_weights = self.state.get("intermediate_weights")
         if current_intermediate_weights:
-            intermediate_weights = np.add(
+            intermediate_weights = ragged_add(
                 current_intermediate_weights, intermediate_weights
             )
 
@@ -612,15 +626,15 @@ class CategoricalAccuracy(Accuracy):
 
         current_correct = self.state.get("correct")
         if current_correct:
-            correct = np.add(current_correct, correct)
+            correct = ragged_add(current_correct, correct)
 
         current_total = self.state.get("total")
         if current_total:
-            total = np.add(current_total, total)
+            total = ragged_add(current_total, total)
 
         current_intermediate_weights = self.state.get("intermediate_weights")
         if current_intermediate_weights:
-            intermediate_weights = np.add(
+            intermediate_weights = ragged_add(
                 current_intermediate_weights, intermediate_weights
             )
 

--- a/synalinks/src/metrics/accuracy_metrics_test.py
+++ b/synalinks/src/metrics/accuracy_metrics_test.py
@@ -329,3 +329,48 @@ class CategoricalAccuracyWithLabelsTest(testing.TestCase):
         score = await metric(y_true, y_pred)
         self.assertAlmostEqual(score, 1.0, delta=3 * backend.epsilon())
         _ = json.dumps(metric.variables[0].get_json())
+
+
+class RaggedStructureAccuracyTest(testing.TestCase):
+    """Variable-length structures: the extraction-bench regression.
+
+    Golds whose arrays hold a different number of items per sample produce a
+    different leaf count per update; the positional state must zero-pad, not
+    crash (np broadcast error), and unmatched leaves within one sample must
+    be scored, not silently dropped by zip truncation."""
+
+    async def test_accumulates_across_different_leaf_counts(self):
+        from typing import List
+
+        class Extraction(DataModel):
+            relations: List[str]
+
+        metric = Accuracy(average="micro")
+        # 3 leaves, all perfect
+        await metric(
+            Extraction(relations=["alpha beta", "gamma delta", "epsilon zeta"]),
+            Extraction(relations=["alpha beta", "gamma delta", "epsilon zeta"]),
+        )
+        # 1 leaf, perfect — pre-fix this raised
+        # "operands could not be broadcast together"
+        await metric(
+            Extraction(relations=["alpha beta"]),
+            Extraction(relations=["alpha beta"]),
+        )
+        self.assertAlmostEqual(metric.result(), 1.0, delta=3 * backend.epsilon())
+
+    async def test_unmatched_leaves_are_penalized_not_dropped(self):
+        from typing import List
+
+        class Extraction(DataModel):
+            relations: List[str]
+
+        metric = Accuracy(average="micro")
+        # Gold has 2 relations, the model only extracted 1 (perfectly):
+        # the missing one must count against the score (0.5), not be
+        # zip-truncated away (1.0).
+        await metric(
+            Extraction(relations=["alpha beta", "gamma delta"]),
+            Extraction(relations=["alpha beta"]),
+        )
+        self.assertAlmostEqual(metric.result(), 0.5, delta=3 * backend.epsilon())

--- a/synalinks/src/metrics/f_score_metrics.py
+++ b/synalinks/src/metrics/f_score_metrics.py
@@ -3,6 +3,7 @@
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
 from collections import Counter
+from itertools import zip_longest
 from typing import List
 from typing import Optional
 
@@ -13,6 +14,7 @@ from synalinks.src.api_export import synalinks_export
 from synalinks.src.backend import DataModel
 from synalinks.src.backend.common import numpy as np
 from synalinks.src.metrics.metric import Metric
+from synalinks.src.metrics.metric import ragged_add
 from synalinks.src.utils import nlp_utils
 
 
@@ -169,7 +171,10 @@ class FBetaScore(Metric):
         # For each field of y_true and y_pred. SQuAD-style multiset (Counter)
         # intersection — needed so identical strings with repeated tokens
         # score 1.0.
-        for yt, yp in zip(y_true, y_pred):
+        # zip_longest, not zip: unmatched leaves (pred and gold structures can
+        # disagree on variable-length arrays) must be scored — the "" fill has
+        # no tokens, so they land entirely in false positives/negatives.
+        for yt, yp in zip_longest(y_true, y_pred, fillvalue=""):
             y_true_tokens = nlp_utils.normalize_and_tokenize(str(yt))
             y_pred_tokens = nlp_utils.normalize_and_tokenize(str(yp))
             num_common = sum((Counter(y_true_tokens) & Counter(y_pred_tokens)).values())
@@ -185,19 +190,19 @@ class FBetaScore(Metric):
 
         current_true_positives = self.state.get("true_positives")
         if current_true_positives:
-            true_positives = np.add(current_true_positives, true_positives)
+            true_positives = ragged_add(current_true_positives, true_positives)
 
         current_false_positives = self.state.get("false_positives")
         if current_false_positives:
-            false_positives = np.add(current_false_positives, false_positives)
+            false_positives = ragged_add(current_false_positives, false_positives)
 
         current_false_negatives = self.state.get("false_negatives")
         if current_false_negatives:
-            false_negatives = np.add(current_false_negatives, false_negatives)
+            false_negatives = ragged_add(current_false_negatives, false_negatives)
 
         current_intermediate_weights = self.state.get("intermediate_weights")
         if current_intermediate_weights:
-            intermediate_weights = np.add(
+            intermediate_weights = ragged_add(
                 current_intermediate_weights, intermediate_weights
             )
 
@@ -532,8 +537,14 @@ class BinaryFBetaScore(FBetaScore):
         y_pred = tree.flatten(
             tree.map_structure(lambda x: convert_to_binary(x), y_pred.get_json())
         )
-        y_true = np.convert_to_tensor(y_true)
-        y_pred = np.convert_to_tensor(y_pred)
+        # Pred and gold structures can disagree on variable-length arrays;
+        # zero-pad to the longer leaf list so the element-wise products below
+        # never hit a broadcast error. A padded gold 0 makes an extra pred
+        # leaf a false positive; a padded pred 0 makes a missing leaf a false
+        # negative — unmatched leaves are penalized, not dropped.
+        size = max(len(y_true), len(y_pred))
+        y_true = np.convert_to_tensor(y_true + [0.0] * (size - len(y_true)))
+        y_pred = np.convert_to_tensor(y_pred + [0.0] * (size - len(y_pred)))
 
         true_positives = y_pred * y_true
         false_positives = y_pred * (1 - y_true)
@@ -542,19 +553,19 @@ class BinaryFBetaScore(FBetaScore):
 
         current_true_positives = self.state.get("true_positives")
         if current_true_positives:
-            true_positives = np.add(current_true_positives, true_positives)
+            true_positives = ragged_add(current_true_positives, true_positives)
 
         current_false_positives = self.state.get("false_positives")
         if current_false_positives:
-            false_positives = np.add(current_false_positives, false_positives)
+            false_positives = ragged_add(current_false_positives, false_positives)
 
         current_false_negatives = self.state.get("false_negatives")
         if current_false_negatives:
-            false_negatives = np.add(current_false_negatives, false_negatives)
+            false_negatives = ragged_add(current_false_negatives, false_negatives)
 
         current_intermediate_weights = self.state.get("intermediate_weights")
         if current_intermediate_weights:
-            intermediate_weights = np.add(
+            intermediate_weights = ragged_add(
                 current_intermediate_weights, intermediate_weights
             )
 
@@ -856,19 +867,19 @@ class CategoricalFBetaScore(FBetaScore):
 
         current_true_positives = self.state.get("true_positives")
         if current_true_positives:
-            true_positives = np.add(current_true_positives, true_positives)
+            true_positives = ragged_add(current_true_positives, true_positives)
 
         current_false_positives = self.state.get("false_positives")
         if current_false_positives:
-            false_positives = np.add(current_false_positives, false_positives)
+            false_positives = ragged_add(current_false_positives, false_positives)
 
         current_false_negatives = self.state.get("false_negatives")
         if current_false_negatives:
-            false_negatives = np.add(current_false_negatives, false_negatives)
+            false_negatives = ragged_add(current_false_negatives, false_negatives)
 
         current_intermediate_weights = self.state.get("intermediate_weights")
         if current_intermediate_weights:
-            intermediate_weights = np.add(
+            intermediate_weights = ragged_add(
                 current_intermediate_weights, intermediate_weights
             )
 

--- a/synalinks/src/metrics/f_score_metrics_test.py
+++ b/synalinks/src/metrics/f_score_metrics_test.py
@@ -479,3 +479,44 @@ class ListAliasTest(testing.TestCase):
         # Backward-compatibility: the legacy names import as the new classes.
         self.assertIs(ListFBetaScore, CategoricalFBetaScore)
         self.assertIs(ListF1Score, CategoricalF1Score)
+
+
+class RaggedStructureFScoreTest(testing.TestCase):
+    """Variable-length structures: the extraction-bench regression (F1 side).
+
+    Same shape bug as the accuracy family: per-update leaf counts vary with
+    the number of items the model extracted, so the positional TP/FP/FN state
+    must zero-pad across updates instead of crashing."""
+
+    async def test_accumulates_across_different_leaf_counts(self):
+        from typing import List
+
+        class Extraction(DataModel):
+            relations: List[str]
+
+        metric = F1Score(average="micro")
+        await metric(
+            Extraction(relations=["alpha beta", "gamma delta", "epsilon zeta"]),
+            Extraction(relations=["alpha beta", "gamma delta", "epsilon zeta"]),
+        )
+        # Pre-fix this raised "operands could not be broadcast together"
+        await metric(
+            Extraction(relations=["alpha beta"]),
+            Extraction(relations=["alpha beta"]),
+        )
+        self.assertAlmostEqual(metric.result(), 1.0, delta=3 * backend.epsilon())
+
+    async def test_unmatched_leaves_are_penalized_not_dropped(self):
+        from typing import List
+
+        class Extraction(DataModel):
+            relations: List[str]
+
+        metric = F1Score(average="micro")
+        # Gold has 2 relations, model extracted 1 perfectly: the missed one
+        # is pure false negatives -> micro F1 = 2/3, not a truncated 1.0.
+        await metric(
+            Extraction(relations=["alpha beta", "gamma delta"]),
+            Extraction(relations=["alpha beta"]),
+        )
+        self.assertAlmostEqual(metric.result(), 2.0 / 3.0, delta=3 * backend.epsilon())

--- a/synalinks/src/metrics/metric.py
+++ b/synalinks/src/metrics/metric.py
@@ -198,3 +198,24 @@ class Metric(SynalinksSaveable):
 
     def __str__(self):
         return self.__repr__()
+
+
+def ragged_add(current, fresh):
+    """Element-wise add of two per-leaf state vectors that may differ in length.
+
+    Metric state is positional (leaf ``i`` of the flattened JSON). Samples
+    with variable-length structures — e.g. an extraction gold whose array
+    holds N items — produce a different leaf count per update, so a plain
+    ``np.add`` raises a broadcast error the moment two updates disagree on
+    length. The shorter vector is zero-padded instead: aggregate sums
+    ("micro") stay exact, and per-position reductions simply see no
+    contribution at positions a sample doesn't have.
+    """
+    from synalinks.src.backend.common import numpy as np
+
+    current = list(current)
+    fresh = list(fresh)
+    size = max(len(current), len(fresh))
+    current = current + [0.0] * (size - len(current))
+    fresh = fresh + [0.0] * (size - len(fresh))
+    return np.add(np.convert_to_numpy(current), np.convert_to_numpy(fresh))

--- a/synalinks/src/version.py
+++ b/synalinks/src/version.py
@@ -3,7 +3,7 @@
 from synalinks.src.api_export import synalinks_export
 
 # Unique source of truth for the version number.
-__version__ = "0.9.006"
+__version__ = "0.9.007"
 
 
 @synalinks_export("synalinks.version")


### PR DESCRIPTION
## Problem

Variable-length structures — e.g. a relation-extraction gold whose array holds N items — produce a different flattened leaf count per sample. This broke the accuracy/F-score metric families in two ways:

1. **Crash (production benches FAILED):** `update_state` accumulates per-leaf state positionally with a plain `np.add`, which raises `operands could not be broadcast together with shapes (28,) (30,)` as soon as two updates disagree on leaf count. Seen as FAILED trials on relation-extraction datasets in the model-lifecycle 1-GPU benches (kgna4secur), killing the whole `program.evaluate` even though the reward path (`metric_reward`, fresh metric per call) was fine.

2. **Silent score inflation:** `zip(y_true, y_pred)` truncated to the shorter leaf list, so a prediction with fewer (or more) leaves than gold had the unmatched ones silently dropped instead of penalized.

## Fix

- New `ragged_add` helper in `metric.py`: zero-pads the shorter state vector before adding. Micro sums stay exact; fixed-schema behavior is unchanged (equal lengths → identical results).
- `zip_longest` with an empty fill at the leaf-pairing loops: unmatched leaves contribute no common tokens (accuracy) and land entirely in false negatives/positives (F-score).
- `BinaryAccuracy` / `BinaryFBetaScore`: zero-pad leaf lists before the element-wise tensor products (same broadcast crash one level deeper) — a padded gold 0 makes an extra pred leaf a false positive, a padded pred 0 makes a missing leaf a false negative.
- Regression tests for both behaviors in both families, including the exact broadcast-crash reproduction.
- Version bump to 0.9.007.

## Behavior change

The truncation fix is a deliberate scoring change: models that under- or over-extract on variable-length outputs now score lower (honestly) on those samples. Fixed-schema datasets are unaffected.

## Tests

`pytest synalinks/src/metrics/ synalinks/src/rewards/` — 207 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)