### PR TITLE
feat(sandbox): confine on macOS via Seatbelt

### DIFF
--- a/synalinks/src/sandboxes/mirage_sandbox.py
+++ b/synalinks/src/sandboxes/mirage_sandbox.py
@@ -140,6 +140,19 @@ _LAUNCHER = "import base64,sys;exec(base64.b64decode(sys.argv[1]))"
 _LIBSANDBOX = "/usr/lib/libsandbox.1.dylib"
 
 _MACOS_CONFINE_SRC = r'''
+# Mach services the confined process may look up, by exact global name. See
+# `_build_sbpl` for why this is an allowlist and not `(allow mach-lookup)`.
+_MACOS_MACH_SERVICES = (
+    # libsystem_notify: registered during libSystem startup.
+    "com.apple.system.notification_center",
+    # os_log / libsystem_trace, touched by the C runtime before main().
+    "com.apple.logd",
+    # opendirectoryd's libinfo endpoint, backing pwd/getpwuid, which CPython
+    # calls from `site` and `os.path.expanduser`.
+    "com.apple.system.opendirectoryd.libinfo",
+)
+
+
 def _sbpl_quote(path):
     """Quote a path for SBPL, which is s-expression syntax, not shell."""
     return '"' + str(path).replace("\\", "\\\\").replace('"', '\\"') + '"'
@@ -150,18 +163,35 @@ def _build_sbpl(cfg):
     lines = [
         "(version 1)",
         "(deny default)",
-        # Keep the process able to run at all: fork/exec for subprocesses the
-        # snippet may spawn, signals to itself, and the Mach/sysctl lookups
-        # dyld and CPython perform during startup. These grant no filesystem
-        # or network reach on their own.
+        # Keep the process able to run at all: fork for subprocesses the snippet
+        # may spawn, signals to itself, and the sysctl reads CPython performs
+        # during startup. These grant no filesystem or network reach.
         "(allow process-fork)",
         "(allow signal (target self))",
         "(allow sysctl-read)",
-        "(allow mach-lookup)",
         # Deny introspection of other processes. Not a PID namespace, but it
         # removes the obvious host-process reconnaissance path.
         "(deny process-info*)",
     ]
+    # Mach services, by explicit name. A bare `(allow mach-lookup)` is the
+    # classic way to render a Seatbelt profile ineffective: a send right to any
+    # service lets the process ask a *daemon* to act for it, and the daemon's
+    # child does not inherit this profile, so the filesystem and network rules
+    # below simply do not apply to the work it performs. Chrome and the Codex /
+    # Gemini CLI profiles all allowlist for this reason.
+    #
+    # This set is deliberately minimal: the notification and logging services
+    # libSystem touches during startup, plus the directory-service lookup that
+    # backs `pwd`/`getpwuid` (CPython's `site` and `os.path.expanduser` call
+    # it). Nothing here brokers process execution. Notably absent, and to stay
+    # absent: `com.apple.coreservices.launchservicesd` and the launchd family,
+    # which exist precisely to spawn processes outside the caller's sandbox.
+    #
+    # Widen only on evidence: a missing service surfaces as the bootstrap
+    # failing closed with `confine-error` and exit 99, never as a silent loss
+    # of confinement, so growing this list from real failures is safe.
+    for service in _MACOS_MACH_SERVICES:
+        lines.append('(allow mach-lookup (global-name "%s"))' % service)
     # Character devices CPython needs; harmless and required for randomness,
     # /dev/null redirection and tty probing.
     for dev in ("/dev/null", "/dev/zero", "/dev/random", "/dev/urandom",
@@ -191,11 +221,15 @@ def _build_sbpl(cfg):
         lines.append("(allow network-outbound (subpath %s))" % _sbpl_quote(sock_dir))
     if cfg.get("network"):
         lines.append("(allow network*)")
-    else:
-        # Loopback stays open: the bridge and any local helper the snippet
-        # legitimately talks to live there, and it grants no egress.
-        lines.append("(allow network-outbound (local ip))")
-        lines.append("(allow network-inbound (local ip))")
+    # Nothing else. Loopback is deliberately NOT granted: unlike Linux, where
+    # NEWNET gives the process a private network namespace whose loopback is
+    # its own, macOS has no namespace and `(local ip)` would be the *host's*
+    # 127.0.0.1. That would hand supposedly network-isolated code every service
+    # bound to localhost (model servers, databases, the user's own dev APIs),
+    # which is exactly what confinement is meant to prevent. The host-tool
+    # bridge does not need it either: it is a unix socket, granted by the
+    # `rpc_socket_dir` rule above, which Seatbelt classes as network-outbound
+    # but matches on path rather than address.
     return "\n".join(lines) + "\n"
 
 

--- a/synalinks/src/sandboxes/mirage_sandbox.py
+++ b/synalinks/src/sandboxes/mirage_sandbox.py
@@ -105,6 +105,140 @@ _LAUNCHER = "import base64,sys;exec(base64.b64decode(sys.argv[1]))"
 # snippet is exec'd under the filename ``<sandbox>`` so tracebacks trim to user
 # frames; its last *expression* (the ``result`` convention) is JSON-encoded
 # to the result file so the host can surface it as ``ExecutionResult.result``.
+# macOS in-process confinement, the Seatbelt counterpart to ``_confine`` below.
+#
+# The Linux path is unavailable here and cannot be ported: namespaces,
+# ``pivot_root``, ``/proc/self/uid_map`` and seccomp are Linux kernel features
+# with no XNU equivalent (POSIX never standardized sandboxing, so every kernel
+# grew its own). macOS instead exposes Seatbelt, the TrustedBSD MAC policy the
+# App Sandbox is built on, which takes a declarative SBPL profile rather than a
+# constructed namespace. ``sandbox_init`` applies one to the *calling* process,
+# which fits this bootstrap exactly as ``_confine`` does: run first, in-process,
+# before the snippet imports anything.
+#
+# What this DOES enforce, kernel-side and without root:
+#   * filesystem: ``(deny default)`` then explicit allows, so the snippet reads
+#     only the Python runtime it needs and writes only the sandbox's own dirs.
+#     Reads are restricted, not just writes (Codex and Gemini CLI both give up
+#     on read restriction; here the runtime read set is known, so we keep it).
+#   * network: denied outright unless ``network`` is set, with the host-tool RPC
+#     socket allowed by literal path so the bridge keeps working either way.
+#   * rlimits: ``setrlimit`` is POSIX and applies unchanged.
+#
+# What it does NOT, and why the docs must not imply Linux parity:
+#   * no PID isolation. XNU has no PID namespace, so the host process table
+#     stays visible; ``(deny process-info*)`` narrows this but is not the same
+#     guarantee as being PID 1 in a fresh namespace.
+#   * no syscall filter. Seatbelt gates MAC operations, not syscall numbers,
+#     so the seccomp denylist has no counterpart. The two models overlap but
+#     neither contains the other.
+#
+# ``sandbox_init`` is deprecated (Apple ship no replacement for non-App-Store
+# process sandboxing) but remains the documented path, still works on current
+# macOS, and underpins Apple's own sandboxes; Chrome, Nix, Bazel, Codex and
+# Gemini CLI all rely on it today.
+_LIBSANDBOX = "/usr/lib/libsandbox.1.dylib"
+
+_MACOS_CONFINE_SRC = r'''
+def _sbpl_quote(path):
+    """Quote a path for SBPL, which is s-expression syntax, not shell."""
+    return '"' + str(path).replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _build_sbpl(cfg):
+    """Render the Seatbelt profile for this run."""
+    lines = [
+        "(version 1)",
+        "(deny default)",
+        # Keep the process able to run at all: fork/exec for subprocesses the
+        # snippet may spawn, signals to itself, and the Mach/sysctl lookups
+        # dyld and CPython perform during startup. These grant no filesystem
+        # or network reach on their own.
+        "(allow process-fork)",
+        "(allow signal (target self))",
+        "(allow sysctl-read)",
+        "(allow mach-lookup)",
+        # Deny introspection of other processes. Not a PID namespace, but it
+        # removes the obvious host-process reconnaissance path.
+        "(deny process-info*)",
+    ]
+    # Character devices CPython needs; harmless and required for randomness,
+    # /dev/null redirection and tty probing.
+    for dev in ("/dev/null", "/dev/zero", "/dev/random", "/dev/urandom",
+                "/dev/dtracehelper", "/dev/tty"):
+        lines.append("(allow file-read* file-write-data (literal %s))"
+                     % _sbpl_quote(dev))
+    # Read-only: the interpreter, its stdlib and the host package dirs, the
+    # same set the Linux path bind-mounts read-only. Without these the snippet
+    # cannot import anything, including its own bootstrap dependencies.
+    for path in cfg.get("read_paths") or []:
+        lines.append("(allow file-read* (subpath %s))" % _sbpl_quote(path))
+    # Execution is limited to that same read-only runtime set, so the snippet
+    # cannot exec an arbitrary host binary it managed to reference.
+    for path in cfg.get("read_paths") or []:
+        lines.append("(allow process-exec (subpath %s))" % _sbpl_quote(path))
+    # Read-write: the sandbox's own directories (dill state, result file, RPC
+    # socket, working tree). This is the only writable surface.
+    for path in cfg.get("rw_paths") or []:
+        lines.append("(allow file-read* file-write* (subpath %s))"
+                     % _sbpl_quote(path))
+    # The host-tool bridge is a unix socket, which Seatbelt classes as network
+    # rather than file I/O, so it needs an explicit allow to survive the
+    # network denial below. The socket is created per run under a random name,
+    # so this grants the containing directory, not a literal path.
+    sock_dir = cfg.get("rpc_socket_dir")
+    if sock_dir:
+        lines.append("(allow network-outbound (subpath %s))" % _sbpl_quote(sock_dir))
+    if cfg.get("network"):
+        lines.append("(allow network*)")
+    else:
+        # Loopback stays open: the bridge and any local helper the snippet
+        # legitimately talks to live there, and it grants no egress.
+        lines.append("(allow network-outbound (local ip))")
+        lines.append("(allow network-inbound (local ip))")
+    return "\n".join(lines) + "\n"
+
+
+def _confine_macos(cfg):
+    import ctypes
+    import ctypes.util
+    import resource
+
+    # rlimits first: POSIX, and unaffected by the profile applied below.
+    rl = cfg.get("rlimits") or {}
+    for key, which in (
+        ("as", getattr(resource, "RLIMIT_AS", None)),
+        ("cpu", getattr(resource, "RLIMIT_CPU", None)),
+        ("nproc", getattr(resource, "RLIMIT_NPROC", None)),
+        ("fsize", getattr(resource, "RLIMIT_FSIZE", None)),
+    ):
+        if rl.get(key) and which is not None:
+            try:
+                resource.setrlimit(which, (rl[key], rl[key]))
+            except (ValueError, OSError):
+                # RLIMIT_NPROC is per-user on Darwin and may already sit below
+                # the request; a tighter existing limit is not a failure.
+                pass
+
+    path = ctypes.util.find_library("sandbox") or "/usr/lib/libsandbox.1.dylib"
+    libsandbox = ctypes.CDLL(path, use_errno=True)
+    libsandbox.sandbox_init.argtypes = [
+        ctypes.c_char_p,
+        ctypes.c_uint64,
+        ctypes.POINTER(ctypes.c_char_p),
+    ]
+    libsandbox.sandbox_init.restype = ctypes.c_int
+    err = ctypes.c_char_p()
+    # flags=0 means "profile is SBPL source", as opposed to one of the named
+    # builtin profiles.
+    rc = libsandbox.sandbox_init(_build_sbpl(cfg).encode("utf-8"), 0,
+                                 ctypes.byref(err))
+    if rc != 0:
+        detail = err.value.decode("utf-8", "replace") if err.value else "unknown"
+        raise OSError("sandbox_init failed: " + detail)
+'''
+
+
 # Rootless in-process confinement, shared by the ``run`` bootstrap and the
 # ``run_bash`` ``_run_python`` patch: enter fresh user/mount/PID(/net)
 # namespaces, fork (PID namespaces only apply to children) so the child is PID 1
@@ -288,10 +422,17 @@ if len(sys.argv) > 3 and sys.argv[3]:
         print("config-warn: " + repr(exc), file=sys.stderr)
 """
     + _CONFINE_SRC
+    + _MACOS_CONFINE_SRC
     + r"""
 if config.get("confine"):
     try:
-        _confine(config)
+        # Same decision the host made in `_confine_config`, re-derived here
+        # rather than trusted from the config: the bootstrap runs on the very
+        # host being confined, so its own platform is the authority.
+        if sys.platform == "darwin":
+            _confine_macos(config)
+        else:
+            _confine(config)
     except Exception as exc:
         print("confine-error: " + repr(exc), file=sys.stderr)
         sys.exit(99)
@@ -670,18 +811,42 @@ def _maybe_warn_native_windows():
 _maybe_warn_native_windows()
 
 
+def confinement_kind() -> Optional[str]:
+    """Which confinement backend this host can use, or ``None`` for neither.
+
+    ``"namespaces"`` on Linux is the strong one: user/mount/PID/net namespaces,
+    a ``pivot_root`` into the virtual filesystem, and a seccomp syscall
+    denylist. ``"seatbelt"`` on macOS enforces the filesystem and network
+    boundaries plus rlimits, but has no PID isolation and no syscall filter,
+    because XNU provides no equivalent of either.
+
+    Callers that need the full guarantee should branch on this rather than on
+    the availability boolean, which only says *some* confinement is possible.
+    """
+    import platform
+
+    system = platform.system()
+    if system == "Linux":
+        return "namespaces"
+    if system == "Darwin":
+        return "seatbelt"
+    return None
+
+
 def _confinement_available() -> tuple[bool, str]:
-    """Whether in-process confinement (FUSE + user-namespace pivot) can run.
+    """Whether in-process confinement can run, by whichever backend fits.
 
     Returns ``(ok, reason)``; ``reason`` explains why not when ``ok`` is False.
-    Requires Linux, ``os.unshare`` (Python 3.12+), ``/dev/fuse``, and
-    unprivileged user namespaces. The confinement is Linux-only by
-    construction (``unshare`` / ``pivot_root`` / FUSE / seccomp have no Windows
-    equivalent), so on Windows the intended path is to run inside **WSL2**,
-    where it works unchanged; the reason string says so, and
-    ``require_confinement=True`` turns that into a hard error rather than a
-    silent unconfined run.
+    On Linux this means ``os.unshare`` (Python 3.12+), ``/dev/fuse``, libfuse
+    and unprivileged user namespaces; on macOS it means Seatbelt's libsandbox.
+    Windows has neither, and the intended path there is to run synalinks inside
+    **WSL2**, where the Linux backend works unchanged; the reason string says
+    so, and ``require_confinement=True`` turns any of these into a hard error
+    rather than a silent unconfined run.
+
+    See `confinement_kind` for *which* backend, and how much it guarantees.
     """
+    import ctypes.util
     import platform
 
     system = platform.system()
@@ -690,8 +855,19 @@ def _confinement_available() -> tuple[bool, str]:
             "confinement requires Linux; on Windows, run synalinks inside WSL2 "
             "(Windows Subsystem for Linux), where confinement works unchanged"
         )
+    if system == "Darwin":
+        # Seatbelt rather than namespaces; see `_MACOS_CONFINE_SRC` for what
+        # that does and does not buy. Weaker than the Linux path (no PID
+        # isolation, no syscall filter), so callers who need the full guarantee
+        # should check `confinement_kind`, not just this boolean.
+        if not (ctypes.util.find_library("sandbox") or os.path.exists(_LIBSANDBOX)):
+            return False, (
+                "confinement requires the macOS Seatbelt library (libsandbox), "
+                "which could not be found"
+            )
+        return True, ""
     if system != "Linux":
-        return False, f"confinement requires Linux (this host is {system})"
+        return False, f"confinement requires Linux or macOS (this host is {system})"
     if not hasattr(os, "unshare"):
         return False, "confinement requires os.unshare (Python 3.12+)"
     if not os.path.exists("/dev/fuse"):
@@ -1189,7 +1365,19 @@ def _install_run_python_patch() -> bool:
         cfg = _active_confine.get()
         if cfg is None:
             return code
-        return "import os\n" + _CONFINE_SRC + "\n_confine(" + repr(cfg) + ")\n" + code
+        # Both prologues are emitted and the platform picked at run time, so a
+        # `python3` the shell spawns self-confines exactly as `run`'s bootstrap
+        # does, on whichever host it lands.
+        return (
+            "import os, sys\n"
+            + _CONFINE_SRC
+            + _MACOS_CONFINE_SRC
+            + "\n_fn = _confine_macos if sys.platform == 'darwin' else _confine\n"
+            + "_fn("
+            + repr(cfg)
+            + ")\n"
+            + code
+        )
 
     if inspect.isclass(owner):
         # 0.0.4+ runtime-table layout: ``async def run(self, RunArgs)``. RunArgs
@@ -1404,7 +1592,7 @@ class MirageSandbox(Sandbox):
     just like a REPL (without replaying earlier snippets), and a snippet that
     raises does not wipe the accumulated namespace.
 
-    ## Confinement (the default; `confine=True`, Linux)
+    ## Confinement (the default; `confine=True`, Linux and macOS)
 
     By default each ``run`` (and any ``python3`` spawned by `run_bash`) is
     **confined**: it enters a fresh user / mount / PID / network namespace and
@@ -1419,15 +1607,37 @@ class MirageSandbox(Sandbox):
     and entirely in-process (no container runtime): the Python subprocess
     sandboxes itself at startup via ``unshare`` + read-only runtime binds +
     ``pivot_root``, with optional ``RLIMIT_*`` caps. Requires Linux,
-    ``/dev/fuse`` and unprivileged user namespaces; elsewhere it falls back to
-    unconfined execution with a ``RuntimeWarning`` (or set
-    ``require_confinement=True`` to make that a hard error).
+    ``/dev/fuse``, libfuse and unprivileged user namespaces; where confinement
+    is unavailable it falls back to unconfined execution with a
+    ``RuntimeWarning`` (or set ``require_confinement=True`` to make that a hard
+    error).
+
+    ## Confinement on macOS (Seatbelt, and how it differs)
+
+    macOS confines through **Seatbelt**, the TrustedBSD MAC policy behind the
+    App Sandbox, because none of the Linux mechanism exists on XNU: namespaces,
+    ``pivot_root``, ``/proc`` and seccomp are Linux kernel features, and POSIX
+    never standardized sandboxing. ``sandbox_init`` applies a default-deny SBPL
+    profile to the process, which **enforces the filesystem and network
+    boundaries plus ``RLIMIT_*``**: the snippet reads only the Python runtime it
+    needs, writes only the sandbox's own directories, and gets no network unless
+    ``network=True`` (the host-tool bridge socket stays reachable either way).
+    Reads are restricted, not merely writes.
+
+    Two guarantees from the Linux path are **absent**, and code that depends on
+    them should check `confinement_kind` rather than assume parity:
+
+    * **no PID isolation** - XNU has no PID namespace, so host processes remain
+      visible. ``(deny process-info*)`` narrows inspection but is not the same.
+    * **no syscall filter** - Seatbelt gates MAC operations, not syscall
+      numbers, so the seccomp denylist has no counterpart.
 
     ## Windows (run under WSL2)
 
-    Confinement is Linux-only by construction: ``unshare`` / ``pivot_root`` /
-    FUSE / seccomp have no native-Windows equivalent. The supported way to get
-    it on Windows is to run synalinks **inside WSL2** (Windows Subsystem for
+    Windows has no confinement backend: ``unshare`` / ``pivot_root`` / FUSE /
+    seccomp have no native-Windows equivalent, and Seatbelt is macOS-only. The
+    supported way to get it on Windows is to run synalinks **inside WSL2**
+    (Windows Subsystem for
     Linux 2): it is a real Linux kernel, so confinement works unchanged, and
     because WSL2 is itself a lightweight VM, the confined process is additionally
     separated from the Windows host by the VM boundary. On **native** Windows
@@ -1775,7 +1985,14 @@ class MirageSandbox(Sandbox):
 
         self._ws = self._new_workspace()
         self._fuse_mountpoint = getattr(self._ws, "fuse_mountpoint", None)
-        if self._require_confinement and not self._fuse_mountpoint:
+        # Only the namespace backend pivots into the FUSE mount; Seatbelt
+        # confines the process in place, so a missing mountpoint is not a
+        # confinement failure there.
+        if (
+            self._require_confinement
+            and not self._fuse_mountpoint
+            and confinement_kind() != "seatbelt"
+        ):
             raise RuntimeError(
                 "MirageSandbox(require_confinement=True): the FUSE mount was not "
                 "established, so the snippet cannot be confined to the virtual "
@@ -1903,6 +2120,19 @@ class MirageSandbox(Sandbox):
             "/lib64",
             "/bin",
         ]
+        if sys.platform == "darwin":
+            # dyld resolves nearly every library out of the shared cache under
+            # /System, and Homebrew prefixes hold the interpreter and its
+            # dependencies on most developer machines. Without these the
+            # Seatbelt profile denies the reads CPython performs before it can
+            # execute a single line of the snippet.
+            candidates += [
+                "/System",
+                "/Library",
+                "/opt/homebrew",
+                "/opt/local",
+                "/private/var/db/dyld",
+            ]
         # Host import locations outside the active prefix, so packages installed
         # in user site / system dist-packages / PYTHONPATH (and editable installs
         # they reference) resolve inside the sandbox. ``site`` re-adds these to
@@ -1930,7 +2160,35 @@ class MirageSandbox(Sandbox):
 
     def _confine_config(self) -> Optional[dict]:
         """Confinement block for the bootstrap config, or ``None`` if disabled."""
-        if not self._confine or not self._fuse_mountpoint:
+        if not self._confine:
+            return None
+        if confinement_kind() == "seatbelt":
+            # No FUSE mount to pivot into on macOS, and none needed: Seatbelt
+            # confines the process where it stands instead of relocating it.
+            # The writable surface is therefore the sandbox's own host dirs,
+            # and the readable surface the same runtime set the Linux path
+            # bind-mounts read-only.
+            rw_paths = [self._hostdir]
+            if self._workdir and os.path.isdir(self._workdir):
+                rw_paths.append(os.path.abspath(self._workdir))
+            # Darwin hands out /var/folders temp dirs through a /private
+            # symlink, and Seatbelt matches on the resolved path, so a profile
+            # written against the unresolved one silently fails to match.
+            rw_paths = [os.path.realpath(p) for p in rw_paths]
+            read_paths = [os.path.realpath(p) for p in self._runtime_binds()]
+            config = {
+                "confine": True,
+                "read_paths": read_paths,
+                "rw_paths": rw_paths,
+                "network": self._confine_network,
+                "rlimits": dict(self._rlimits),
+            }
+            # The per-run RPC socket is created inside the host dir under a
+            # random name, so the profile allows the directory rather than a
+            # literal path it cannot know yet.
+            config["rpc_socket_dir"] = os.path.realpath(self._hostdir)
+            return config
+        if not self._fuse_mountpoint:
             return None
         config = {
             "confine": True,
@@ -2281,7 +2539,11 @@ class MirageSandbox(Sandbox):
         # mountpoint so a confined sandbox pivots into the live mount (and
         # ``require_confinement`` still holds) after a reset.
         self._fuse_mountpoint = getattr(self._ws, "fuse_mountpoint", None)
-        if self._require_confinement and not self._fuse_mountpoint:
+        if (
+            self._require_confinement
+            and not self._fuse_mountpoint
+            and confinement_kind() != "seatbelt"
+        ):
             raise RuntimeError(
                 "MirageSandbox(require_confinement=True): the FUSE mount was not "
                 "re-established after reset; cannot confine."

--- a/synalinks/src/sandboxes/mirage_sandbox_test.py
+++ b/synalinks/src/sandboxes/mirage_sandbox_test.py
@@ -1287,9 +1287,19 @@ class SbplProfileTest(testing.TestCase):
 
     def test_network_denied_by_default(self):
         profile = self._build()
-        # No blanket grant, and loopback only. `(deny default)` covers the rest.
+        # `(deny default)` covers everything; nothing re-opens it.
         self.assertNotIn("(allow network*)", profile)
-        self.assertIn("(allow network-outbound (local ip))", profile)
+
+    def test_host_loopback_is_never_granted(self):
+        # macOS has no network namespace, so `(local ip)` would be the *host's*
+        # 127.0.0.1: every service bound to localhost would be reachable from
+        # code that is supposed to have no network at all. Assert both
+        # directions, and under both network settings, since the blanket
+        # `(allow network*)` is the only intended way to get out.
+        for network in (False, True):
+            profile = self._build(network=network)
+            self.assertNotIn("(local ip)", profile)
+            self.assertNotIn("network-inbound", profile)
 
     def test_network_allowed_when_requested(self):
         profile = self._build(network=True)
@@ -1304,6 +1314,28 @@ class SbplProfileTest(testing.TestCase):
     def test_process_info_is_denied(self):
         profile = self._build()
         self.assertIn("(deny process-info*)", profile)
+
+    def test_mach_lookup_is_never_unrestricted(self):
+        # A bare `(allow mach-lookup)` lets the process ask any daemon to work
+        # on its behalf, and the daemon's child does not inherit this profile,
+        # so the filesystem and network rules would not apply to it. Every
+        # grant must name a specific service.
+        profile = self._build()
+        self.assertNotIn("(allow mach-lookup)\n", profile)
+        for line in profile.splitlines():
+            if "mach-lookup" in line:
+                self.assertIn("global-name", line)
+
+    def test_mach_lookup_allows_only_known_services(self):
+        profile = self._build()
+        self.assertIn(
+            '(allow mach-lookup (global-name "com.apple.system.notification_center"))',
+            profile,
+        )
+        # Process-spawning brokers are the escape route this allowlist exists
+        # to close, so they must never appear.
+        self.assertNotIn("launchservicesd", profile)
+        self.assertNotIn("com.apple.launchd", profile)
 
     def test_paths_with_quotes_are_escaped(self):
         # SBPL is s-expression syntax: an unescaped quote in a path would end

--- a/synalinks/src/sandboxes/mirage_sandbox_test.py
+++ b/synalinks/src/sandboxes/mirage_sandbox_test.py
@@ -4,13 +4,24 @@ import gc
 import unittest
 
 from synalinks.src import testing
+from synalinks.src.sandboxes.mirage_sandbox import _MACOS_CONFINE_SRC
 from synalinks.src.sandboxes.mirage_sandbox import MirageSandbox
 from synalinks.src.sandboxes.mirage_sandbox import _confinement_available
+from synalinks.src.sandboxes.mirage_sandbox import confinement_kind
 from synalinks.src.sandboxes.sandbox import ExecutionResult
 from synalinks.src.sandboxes.sandbox import Sandbox
 
 _TIMEOUT = 30.0
 _CONFINE_OK, _CONFINE_REASON = _confinement_available()
+# The tests below assert namespace-specific behaviour (PID namespaces, seccomp,
+# the pivot_root filesystem swap), so they gate on the *backend* rather than on
+# confinement being available at all. macOS now reports confinement available
+# too, via Seatbelt, which enforces a deliberately different and weaker set;
+# `MacosSeatbeltConfineTest` covers what it does guarantee.
+_KIND = confinement_kind()
+_NAMESPACES_OK = _CONFINE_OK and _KIND == "namespaces"
+_SEATBELT_OK = _CONFINE_OK and _KIND == "seatbelt"
+_NS_REASON = f"namespace confinement unavailable: {_CONFINE_REASON or _KIND}"
 
 
 class _SandboxTestCase(testing.TestCase):
@@ -394,7 +405,7 @@ class MirageSandboxTest(_SandboxTestCase):
         )
         self.assertEqual(sandbox.granted_capabilities()["mounts"]["/rw"], "WRITE")
 
-    @unittest.skipUnless(_CONFINE_OK, f"confinement unavailable: {_CONFINE_REASON}")
+    @unittest.skipUnless(_NAMESPACES_OK, _NS_REASON)
     async def test_unvouched_runtime_stripped_under_confine(self):
         # A runtime the sandbox cannot vouch for could execute code on the host
         # outside the confinement prologue, so it is dropped (with a warning)
@@ -412,7 +423,7 @@ class MirageSandboxTest(_SandboxTestCase):
         self.assertEqual(sandbox._workspace_kwargs["runtimes"], ["vfs"])
         sandbox.close()
 
-    @unittest.skipUnless(_CONFINE_OK, f"confinement unavailable: {_CONFINE_REASON}")
+    @unittest.skipUnless(_NAMESPACES_OK, _NS_REASON)
     async def test_unvouched_runtime_rejected_under_require_confinement(self):
         with self.assertRaises(ValueError):
             MirageSandbox(
@@ -422,7 +433,7 @@ class MirageSandboxTest(_SandboxTestCase):
                 workspace_kwargs={"runtimes": ["not-a-vouched-runtime"]},
             )
 
-    @unittest.skipUnless(_CONFINE_OK, f"confinement unavailable: {_CONFINE_REASON}")
+    @unittest.skipUnless(_NAMESPACES_OK, _NS_REASON)
     async def test_local_runtime_allowed_under_confinement_when_patched(self):
         # 'local' reaches the host, but the run-python patch prepends the
         # confinement prologue to everything it runs, so it is the one
@@ -435,7 +446,7 @@ class MirageSandboxTest(_SandboxTestCase):
         finally:
             sandbox.close()
 
-    @unittest.skipUnless(_CONFINE_OK, f"confinement unavailable: {_CONFINE_REASON}")
+    @unittest.skipUnless(_NAMESPACES_OK, _NS_REASON)
     async def test_local_runtime_rejected_when_patch_unavailable(self):
         # Fail-closed: if the confinement prologue cannot be installed, 'local'
         # is an unguarded hole and require_confinement must refuse to build.
@@ -744,7 +755,7 @@ class MirageSandboxTest(_SandboxTestCase):
             shutil.rmtree(workdir, ignore_errors=True)
 
 
-@unittest.skipUnless(_CONFINE_OK, f"confinement unavailable: {_CONFINE_REASON}")
+@unittest.skipUnless(_NAMESPACES_OK, _NS_REASON)
 class MirageSandboxConfineTest(_SandboxTestCase):
     """In-process confinement (FUSE + user-namespace pivot), Linux-only."""
 
@@ -1232,3 +1243,155 @@ class InfraSelfHealTest(_SandboxTestCase):
         self.assertEqual(calls["exec"], 1)
         self.assertFalse(result.ok)
         self.assertIn("ValueError", result.error)
+
+
+class SbplProfileTest(testing.TestCase):
+    """Unit tests for the generated Seatbelt profile.
+
+    Pure string generation, so these run on every platform. They are the only
+    part of the macOS backend that can be checked off a Darwin host, which
+    makes them the first line of defence against a profile that silently grants
+    more than intended.
+    """
+
+    def _build(self, **overrides):
+        cfg = {
+            "read_paths": ["/usr", "/System"],
+            "rw_paths": ["/private/tmp/sbx"],
+            "network": False,
+        }
+        cfg.update(overrides)
+        ns = {}
+        exec(_MACOS_CONFINE_SRC, ns)
+        return ns["_build_sbpl"](cfg)
+
+    def test_profile_is_default_deny(self):
+        # Everything else in the profile is an exception to this line; without
+        # it the profile grants the world.
+        profile = self._build()
+        self.assertIn("(version 1)", profile)
+        self.assertIn("(deny default)", profile)
+
+    def test_read_paths_are_read_only(self):
+        profile = self._build()
+        self.assertIn('(allow file-read* (subpath "/usr"))', profile)
+        # The runtime set must never become writable: that is what stops the
+        # snippet rewriting the interpreter it is about to run under.
+        self.assertNotIn('(allow file-read* file-write* (subpath "/usr"))', profile)
+
+    def test_rw_paths_are_writable(self):
+        profile = self._build()
+        self.assertIn(
+            '(allow file-read* file-write* (subpath "/private/tmp/sbx"))', profile
+        )
+
+    def test_network_denied_by_default(self):
+        profile = self._build()
+        # No blanket grant, and loopback only. `(deny default)` covers the rest.
+        self.assertNotIn("(allow network*)", profile)
+        self.assertIn("(allow network-outbound (local ip))", profile)
+
+    def test_network_allowed_when_requested(self):
+        profile = self._build(network=True)
+        self.assertIn("(allow network*)", profile)
+
+    def test_rpc_socket_dir_is_allowed_even_without_network(self):
+        # The host-tool bridge is a unix socket, which Seatbelt treats as
+        # network; without this the bridge would break under the denial above.
+        profile = self._build(rpc_socket_dir="/private/tmp/sbx")
+        self.assertIn('(allow network-outbound (subpath "/private/tmp/sbx"))', profile)
+
+    def test_process_info_is_denied(self):
+        profile = self._build()
+        self.assertIn("(deny process-info*)", profile)
+
+    def test_paths_with_quotes_are_escaped(self):
+        # SBPL is s-expression syntax: an unescaped quote in a path would end
+        # the string early and could terminate the rule, so a crafted directory
+        # name must not be able to edit the profile.
+        profile = self._build(rw_paths=['/tmp/a"b'])
+        self.assertIn(r'"/tmp/a\"b"', profile)
+        self.assertNotIn('"/tmp/a"b"', profile)
+
+
+@unittest.skipUnless(_SEATBELT_OK, f"seatbelt confinement unavailable: {_KIND}")
+class MacosSeatbeltConfineTest(_SandboxTestCase):
+    """Behavioural checks for the macOS backend, on a real Darwin host.
+
+    These assert the boundary actually holds, rather than that the profile
+    merely renders. Seatbelt gives no PID isolation and no syscall filter, so
+    there is deliberately no counterpart here to the namespace suite's
+    `test_confine_pid_namespace_hides_host_processes` or
+    `test_confine_seccomp_blocks_denied_syscall`.
+    """
+
+    async def test_confinement_kind_is_seatbelt(self):
+        self.assertEqual(confinement_kind(), "seatbelt")
+
+    async def test_confined_run_still_works(self):
+        # The boundary is worthless if it also breaks execution: the snippet
+        # must still import, run and keep state across calls.
+        sandbox = MirageSandbox(timeout=_TIMEOUT, confine=True)
+        await sandbox.run("import json\nkeep = json.dumps({'a': 1})")
+        result = await sandbox.run("print(keep)")
+        self.assertTrue(result.ok, msg=result.error)
+        self.assertIn('{"a": 1}', result.stdout)
+
+    async def test_confine_blocks_write_outside_sandbox(self):
+        sandbox = MirageSandbox(timeout=_TIMEOUT, confine=True)
+        result = await sandbox.run(
+            "import os\n"
+            "target = os.path.expanduser('~/synalinks_seatbelt_escape.txt')\n"
+            "try:\n"
+            "    open(target, 'w').write('escaped')\n"
+            "    outcome = 'WROTE'\n"
+            "except Exception as exc:\n"
+            "    outcome = type(exc).__name__\n"
+            "print(outcome)\n"
+        )
+        self.assertTrue(result.ok, msg=result.error)
+        self.assertNotIn("WROTE", result.stdout)
+        self.assertIn("Error", result.stdout)
+
+    async def test_confine_blocks_read_outside_runtime_set(self):
+        # Reads are restricted, unlike the Codex/Gemini Seatbelt profiles which
+        # allow the whole disk. /etc/passwd is readable on any unconfined mac.
+        sandbox = MirageSandbox(timeout=_TIMEOUT, confine=True)
+        result = await sandbox.run(
+            "try:\n"
+            "    open('/etc/passwd').read()\n"
+            "    outcome = 'READ'\n"
+            "except Exception as exc:\n"
+            "    outcome = type(exc).__name__\n"
+            "print(outcome)\n"
+        )
+        self.assertTrue(result.ok, msg=result.error)
+        self.assertNotIn("READ", result.stdout)
+
+    async def test_confine_cuts_network(self):
+        sandbox = MirageSandbox(timeout=_TIMEOUT, confine=True)
+        result = await sandbox.run(
+            "import socket\n"
+            "s = socket.socket()\n"
+            "s.settimeout(5)\n"
+            "try:\n"
+            "    s.connect(('1.1.1.1', 80))\n"
+            "    outcome = 'CONNECTED'\n"
+            "except Exception as exc:\n"
+            "    outcome = type(exc).__name__\n"
+            "print(outcome)\n"
+        )
+        self.assertTrue(result.ok, msg=result.error)
+        self.assertNotIn("CONNECTED", result.stdout)
+
+    async def test_confine_writes_inside_sandbox_still_work(self):
+        # The complement of the escape test: the sandbox's own writable area
+        # must stay writable, or the boundary is just breakage.
+        sandbox = MirageSandbox(timeout=_TIMEOUT, confine=True)
+        result = await sandbox.run(
+            "import os, tempfile\n"
+            "p = os.path.join(tempfile.gettempdir(), 'inside.txt')\n"
+            "open(p, 'w').write('ok')\n"
+            "print('WROTE_INSIDE')\n"
+        )
+        self.assertTrue(result.ok, msg=result.error)


### PR DESCRIPTION
Draft until macOS CI confirms the behavioural tests, since CI is the only Darwin host available to develop this against.

Stacked on `feat/graphrag-global-search` (#83) to avoid a large conflict in `mirage_sandbox.py`; retarget to `main` once that merges.

## The problem

`_confinement_available()` rejected every non-Linux host on the platform check, so a default `MirageSandbox()` on macOS warned and ran the LM's code **unconfined**. This was never a regression, it was simply the Linux backend being the only one implemented.

None of the Linux mechanism ports: namespaces, `pivot_root`, `/proc/self/uid_map` and seccomp are Linux kernel features. POSIX never standardized sandboxing, so each kernel grew its own (Linux namespaces, macOS Seatbelt, FreeBSD jails, OpenBSD `pledge`).

## The approach

macOS gets **Seatbelt**, the TrustedBSD MAC policy behind the App Sandbox. `sandbox_init` applies a default-deny SBPL profile to the calling process, which fits this bootstrap exactly as the namespace path does: run first, in-process, before the snippet imports anything. `_MACOS_CONFINE_SRC` sits alongside `_CONFINE_SRC`, both prologues are emitted, and the platform is resolved at run time so a `python3` the shell spawns self-confines wherever it lands.

`sandbox_init` is deprecated with [no replacement for non-App-Store process sandboxing](https://github.com/apple/containerization/issues/737), but it is the documented path, still works, underpins Apple's own sandboxes, and is what Chrome, Nix, Bazel, [Codex](https://codex.danielvaughan.com/2026/04/08/codex-sandbox-platform-implementation/) and [Gemini CLI](https://github.com/google-gemini/gemini-cli/pull/22832) rely on today. That is a bet others have made, not a safe one.

## What macOS does and does not get

| | Linux (`namespaces`) | macOS (`seatbelt`) |
|---|---|---|
| host filesystem hidden | `pivot_root` | default-deny + explicit allows |
| reads restricted | ✅ | ✅ (Codex/Gemini both give this up; the runtime read set is known here) |
| network cut | `NEWNET` | `(deny default)`, loopback + bridge socket only |
| `RLIMIT_*` | ✅ | ✅ |
| **PID isolation** | ✅ PID 1 in a fresh namespace | ❌ no PID namespace on XNU; `(deny process-info*)` narrows, does not equal |
| **syscall filter** | ✅ seccomp denylist | ❌ Seatbelt gates MAC operations, not syscall numbers |

New `confinement_kind()` returns `"namespaces"` / `"seatbelt"` / `None`, so callers needing the full guarantee branch on the backend rather than on the availability boolean. The class docstring states the two gaps rather than implying parity.

## Gates that assumed Linux

`_confine_config()` returned `None` without a FUSE mountpoint, and `require_confinement=True` raised for the same reason. Seatbelt confines the process where it stands and needs no mount, so both are now namespace-only — otherwise `require_confinement=True` would have raised on macOS *despite* confinement working.

The namespace-specific tests move from `_CONFINE_OK` to `_NAMESPACES_OK`, so macOS does not attempt seccomp/PID-namespace assertions now that it reports confinement available.

## Testing

Profile generation is unit-tested on **every** platform, which is the only part checkable off a Darwin host: default-deny present, runtime set never writable, network denied unless asked, and SBPL quoting so a crafted directory name cannot terminate a string and edit the profile.

Behavioural tests are Darwin-gated and assert the boundary actually holds rather than that the profile merely renders: no write outside the sandbox, no read of `/etc/passwd`, no outbound connection, while execution and state persistence keep working.

Linux is unchanged: **2137 passed, 6 skipped** (the Darwin-gated tests), ruff and black clean.

## Review focus

The SBPL allow-list is the security boundary and I could not exercise it locally. Worth a close read of the read/exec allows in `_build_sbpl` and the `read_paths` set — too narrow only breaks imports, too broad silently weakens the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)