### PR TITLE
fix(knowledge-bases): treat an existing FTS index as success, not failure

### DIFF
--- a/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter.py
+++ b/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter.py
@@ -673,6 +673,13 @@ class LadybugAdapter(GraphDatabaseAdapter):
                 f"[{col_list}]{options_fragment})"
             )
         except Exception as e:  # noqa: BLE001
+            # Reopening a persistent store re-declares every entity model, so
+            # the index built in a previous session is still there. That is
+            # the already-correct state, not a failure — the write paths
+            # rebuild it on the next insert. Warning here would tell the user
+            # their full-text search is dead when it works fine.
+            if "already exists" in str(e).lower():
+                return
             warnings.warn(
                 f"Failed to create FTS index for {label!r}: {e}. "
                 f"Full-text search on {label!r} will return no results."

--- a/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter_test.py
+++ b/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter_test.py
@@ -477,6 +477,27 @@ class LadybugAdapterTest(testing.TestCase):
             results = await adapter.entity_fulltext_search("Alice", label="Person")
         self.assertEqual(len(results), 1)
 
+    async def test_creating_an_existing_fts_index_is_silent(self):
+        """Reopening a persistent store re-declares its entity models, so
+        the index from the previous session is already there. That is the
+        correct state, and search still works — warning about it would tell
+        the user their full-text search is dead when it isn't."""
+        import warnings as _warnings
+
+        adapter = self._adapter(embedding_model=_StubEmbeddingModel({}))
+        await adapter.update_entities(
+            Person(label="Person", name="Alice", embedding=[1.0, 0.0, 0.0])
+        )
+
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            # Same call the constructor makes for a declared entity model.
+            adapter._create_fts_index("Person", adapter._fts_columns["Person"])
+        self.assertEqual([str(w.message) for w in caught], [])
+
+        results = await adapter.entity_fulltext_search("Alice", label="Person")
+        self.assertEqual(len(results), 1)
+
     # ------------------------------------------------------------------
     # Lifecycle, raw queries, edge cases
     # ------------------------------------------------------------------


### PR DESCRIPTION
## The bug

Reopening a persistent Ladybug store re-declares every `entity_models` entry, so `CREATE_FTS_INDEX` runs again against the index the previous session already built and Ladybug raises:

```
Binder exception: Index primitive_fts already exists in table Primitive.
```

`_create_fts_index` caught it and warned:

```
UserWarning: Failed to create FTS index for 'Primitive': Binder exception: Index
primitive_fts already exists in table Primitive.. Full-text search on 'Primitive'
will return no results.
```

That claim is backwards. The index exists, it is current as of the last write (`update_entities` rebuilds it), and `entity_fulltext_search` works fine. Every reopen of a persistent graph printed a warning telling the user a working feature was dead.

## The fix

Swallow the already-exists case; keep warning on every other failure, where the message is accurate.

## Test

`test_creating_an_existing_fts_index_is_silent` calls `_create_fts_index` a second time — the same call the constructor makes for a declared entity model — asserts no warning is emitted, and asserts full-text search still returns the row. It fails on `main` (one warning) and passes with the fix.

`pytest synalinks/src/knowledge_bases -q` → 417 passed.

## How it turned up

Building an agent that keeps a library of Python functions in a graph-backed `KnowledgeBase`: every run after the first one opened `ladybug://./primitives.lb` and printed the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)