### PR TITLE
feat: built-in read_skill tool completes progressive disclosure for Agent Skills

### DIFF
--- a/synalinks/src/modules/agents/function_calling_agent.py
+++ b/synalinks/src/modules/agents/function_calling_agent.py
@@ -16,6 +16,8 @@ from synalinks.src.modules.agents.utils.agents_utils import discover_agents_md
 from synalinks.src.modules.agents.utils.agents_utils import merge_tools
 from synalinks.src.modules.agents.utils.agents_utils import prepend_context_message
 from synalinks.src.modules.agents.utils.agents_utils import resolve_workdir
+from synalinks.src.modules.agents.utils.skills_utils import READ_SKILL_TOOL_NAME
+from synalinks.src.modules.agents.utils.skills_utils import build_read_skill_tool
 from synalinks.src.modules.agents.utils.skills_utils import discover_skills_in_roots
 from synalinks.src.modules.agents.utils.skills_utils import resolve_skills_paths
 from synalinks.src.modules.agents.utils.skills_utils import skills_prompt
@@ -390,9 +392,14 @@ class FunctionCallingAgent(Module):
             agentskills.io standard). The discovered skills' names and
             descriptions are injected as an ``<available_skills>`` context
             message so the agent knows what is available; per progressive
-            disclosure, each skill's full ``SKILL.md`` body and bundled files are
-            read on demand through the agent's own file/bash tools. Each path
-            must point to an existing directory (Default to None).
+            disclosure, each skill's full ``SKILL.md`` body and bundled files
+            are read on demand. Setting `skills` also adds a built-in
+            ``read_skill`` tool for exactly that (reads confined to the skill
+            directories), so agents without file/bash tools can still follow
+            their skills; an existing tool named ``read_skill`` (from a
+            subclass or the `tools` argument) takes precedence over the
+            built-in. Each path must point to an existing directory
+            (Default to None).
         streaming (bool): Optional. If true, stream the final answer. Only takes
             effect when no `data_model`/`schema` is provided. When streaming,
             the agent returns a `StreamingIterator` instead of a wrapped
@@ -474,11 +481,14 @@ class FunctionCallingAgent(Module):
         self.language_model = _get_lm(language_model)
 
         # Built-in tools come from the `_get_builtin_tools` hook (empty for the
-        # base agent; subclasses inject domain tools). User-supplied `tools`
-        # are merged on top, with name-collision and underscore checks.
+        # base agent; subclasses inject domain tools), plus the skill-reading
+        # tool when Agent Skills are configured. User-supplied `tools` are
+        # merged on top, with name-collision and underscore checks.
         self.extra_tools = list(tools) if tools else []
+        builtin_tools = list(self._get_builtin_tools())
+        builtin_tools += self._skills_tools(builtin_tools)
         merged_tools = merge_tools(
-            self._get_builtin_tools(),
+            builtin_tools,
             self.extra_tools,
             kind=self._builtin_tool_kind(),
         )
@@ -548,6 +558,33 @@ class FunctionCallingAgent(Module):
         the hook depends on must be assigned *before* ``super().__init__()``.
         """
         return []
+
+    def _skills_tools(self, builtin_tools):
+        """The skill-reading built-in, when Agent Skills are configured.
+
+        The ``<available_skills>`` context block lists only names and
+        descriptions; the spec expects the agent to read the bodies through
+        its own file tools, which a tool-calling agent equipped with domain
+        tools does not have — its skills would be advertised but unreadable.
+        So whenever `skills` roots are set, a built-in ``read_skill`` tool is
+        added to complete progressive disclosure (the ``SKILL.md`` body and
+        bundled files, confined to the skill directories).
+
+        Skipped when a tool named ``read_skill`` already exists — a
+        subclass's or the caller's own reader wins over the built-in one.
+        Not serialized: like every built-in it is rebuilt from the `skills`
+        config on reload.
+        """
+        if not self.skills:
+            return []
+        taken = {tool.name for tool in builtin_tools}
+        for extra in self.extra_tools:
+            taken.add(
+                extra.name if hasattr(extra, "name") else getattr(extra, "__name__", "")
+            )
+        if READ_SKILL_TOOL_NAME in taken:
+            return []
+        return [build_read_skill_tool(self.skills)]
 
     def _builtin_tool_kind(self):
         """Short noun naming the built-in tool family, used in collision errors."""

--- a/synalinks/src/modules/agents/function_calling_agent.py
+++ b/synalinks/src/modules/agents/function_calling_agent.py
@@ -392,14 +392,16 @@ class FunctionCallingAgent(Module):
             agentskills.io standard). The discovered skills' names and
             descriptions are injected as an ``<available_skills>`` context
             message so the agent knows what is available; per progressive
-            disclosure, each skill's full ``SKILL.md`` body and bundled files
-            are read on demand. Setting `skills` also adds a built-in
-            ``read_skill`` tool for exactly that (reads confined to the skill
-            directories), so agents without file/bash tools can still follow
-            their skills; an existing tool named ``read_skill`` (from a
-            subclass or the `tools` argument) takes precedence over the
-            built-in. Each path must point to an existing directory
-            (Default to None).
+            disclosure, each skill's full ``SKILL.md`` body is read on
+            demand: setting `skills` also adds a built-in ``read_skill(name)``
+            tool, so agents without file/bash tools can still follow their
+            skills. Skills are addressed **by name only** — storage stays
+            internal and no path is exposed to the model (the listing is
+            rendered without ``<location>``); bundled ``references/`` files
+            remain the province of agents with real file tools. An existing
+            tool named ``read_skill`` (from a subclass or the `tools`
+            argument) takes precedence over the built-in. Each path must
+            point to an existing directory (Default to None).
         streaming (bool): Optional. If true, stream the final answer. Only takes
             effect when no `data_model`/`schema` is provided. When streaming,
             the agent returns a `StreamingIterator` instead of a wrapped
@@ -638,7 +640,12 @@ class FunctionCallingAgent(Module):
         skills = discover_skills_in_roots(self.skills)
         if not skills:
             return None
-        return ChatMessage(role=ChatRole.USER, content=skills_prompt(skills))
+        # Rendered without <location>: this agent reads skills by name
+        # (the built-in or an overriding `read_skill` tool), so a
+        # filesystem path would only leak an implementation detail.
+        return ChatMessage(
+            role=ChatRole.USER, content=skills_prompt(skills, locations=False)
+        )
 
     async def call(self, inputs, training=False, **kwargs):
         if not inputs:

--- a/synalinks/src/modules/agents/function_calling_agent_test.py
+++ b/synalinks/src/modules/agents/function_calling_agent_test.py
@@ -1100,7 +1100,7 @@ class SkillsToolWiringTest(testing.TestCase):
             skills=[self._make_skills_root()],
         )
         self.assertIn("read_skill", agent.tools)
-        report = await agent.tools["read_skill"](skill="pdf-processing")
+        report = await agent.tools["read_skill"](name="pdf-processing")
         self.assertIn("pdfplumber", report.get_json()["content"])
 
     async def test_no_skills_no_read_skill_tool(self):
@@ -1111,11 +1111,11 @@ class SkillsToolWiringTest(testing.TestCase):
         self.assertNotIn("read_skill", agent.tools)
 
     async def test_user_read_skill_tool_wins_over_builtin(self):
-        async def read_skill(skill: str):
+        async def read_skill(name: str):
             """Custom reader.
 
             Args:
-                skill (str): The skill name.
+                name (str): The skill name.
             """
             return {"custom": True}
 
@@ -1124,7 +1124,7 @@ class SkillsToolWiringTest(testing.TestCase):
             tools=[Tool(read_skill)],
             skills=[self._make_skills_root()],
         )
-        report = await agent.tools["read_skill"](skill="x")
+        report = await agent.tools["read_skill"](name="x")
         self.assertTrue(report.get_json()["custom"])
 
     async def test_skill_tool_alone_satisfies_the_tools_requirement(self):
@@ -1135,6 +1135,15 @@ class SkillsToolWiringTest(testing.TestCase):
             skills=[self._make_skills_root()],
         )
         self.assertEqual(list(agent.tools), ["read_skill"])
+
+    async def test_skills_listing_has_no_location(self):
+        agent = FunctionCallingAgent(
+            language_model=LanguageModel(model="ollama/mistral"),
+            skills=[self._make_skills_root()],
+        )
+        content = agent.skills_message.content
+        self.assertIn("pdf-processing", content)
+        self.assertNotIn("<location>", content)
 
     async def test_skill_tool_survives_serialization_roundtrip(self):
         root = self._make_skills_root()

--- a/synalinks/src/modules/agents/function_calling_agent_test.py
+++ b/synalinks/src/modules/agents/function_calling_agent_test.py
@@ -1100,7 +1100,7 @@ class SkillsToolWiringTest(testing.TestCase):
             skills=[self._make_skills_root()],
         )
         self.assertIn("read_skill", agent.tools)
-        report = await agent.tools["read_skill"](name="pdf-processing", file="")
+        report = await agent.tools["read_skill"](skill="pdf-processing")
         self.assertIn("pdfplumber", report.get_json()["content"])
 
     async def test_no_skills_no_read_skill_tool(self):
@@ -1111,12 +1111,11 @@ class SkillsToolWiringTest(testing.TestCase):
         self.assertNotIn("read_skill", agent.tools)
 
     async def test_user_read_skill_tool_wins_over_builtin(self):
-        async def read_skill(name: str, file: str):
+        async def read_skill(skill: str):
             """Custom reader.
 
             Args:
-                name (str): The skill name.
-                file (str): The file to read.
+                skill (str): The skill name.
             """
             return {"custom": True}
 
@@ -1125,7 +1124,7 @@ class SkillsToolWiringTest(testing.TestCase):
             tools=[Tool(read_skill)],
             skills=[self._make_skills_root()],
         )
-        report = await agent.tools["read_skill"](name="x", file="")
+        report = await agent.tools["read_skill"](skill="x")
         self.assertTrue(report.get_json()["custom"])
 
     async def test_skill_tool_alone_satisfies_the_tools_requirement(self):

--- a/synalinks/src/modules/agents/function_calling_agent_test.py
+++ b/synalinks/src/modules/agents/function_calling_agent_test.py
@@ -1075,3 +1075,77 @@ class FunctionCallingAgentTest(testing.TestCase):
             if isinstance(m.get("content"), str) and "<available_skills>" in m["content"]
         )
         self.assertEqual(skills_count, 1)
+
+
+class SkillsToolWiringTest(testing.TestCase):
+    """The built-in `read_skill` tool added when Agent Skills are configured."""
+
+    def _make_skills_root(self):
+        root = tempfile.mkdtemp()
+        skill_dir = os.path.join(root, "pdf-processing")
+        os.makedirs(skill_dir)
+        with open(os.path.join(skill_dir, "SKILL.md"), "w") as f:
+            f.write(
+                "---\n"
+                "name: pdf-processing\n"
+                "description: Extract PDF text. Use when handling PDFs.\n"
+                "---\n"
+                "Use pdfplumber.\n"
+            )
+        return root
+
+    async def test_skills_add_builtin_read_skill_tool(self):
+        agent = FunctionCallingAgent(
+            language_model=LanguageModel(model="ollama/mistral"),
+            skills=[self._make_skills_root()],
+        )
+        self.assertIn("read_skill", agent.tools)
+        report = await agent.tools["read_skill"](name="pdf-processing", file="")
+        self.assertIn("pdfplumber", report.get_json()["content"])
+
+    async def test_no_skills_no_read_skill_tool(self):
+        agent = FunctionCallingAgent(
+            language_model=LanguageModel(model="ollama/mistral"),
+            tools=[Tool(calculate)],
+        )
+        self.assertNotIn("read_skill", agent.tools)
+
+    async def test_user_read_skill_tool_wins_over_builtin(self):
+        async def read_skill(name: str, file: str):
+            """Custom reader.
+
+            Args:
+                name (str): The skill name.
+                file (str): The file to read.
+            """
+            return {"custom": True}
+
+        agent = FunctionCallingAgent(
+            language_model=LanguageModel(model="ollama/mistral"),
+            tools=[Tool(read_skill)],
+            skills=[self._make_skills_root()],
+        )
+        report = await agent.tools["read_skill"](name="x", file="")
+        self.assertTrue(report.get_json()["custom"])
+
+    async def test_skill_tool_alone_satisfies_the_tools_requirement(self):
+        # With skills set, the built-in reader counts as a tool, so an agent
+        # may be constructed without any user tools.
+        agent = FunctionCallingAgent(
+            language_model=LanguageModel(model="ollama/mistral"),
+            skills=[self._make_skills_root()],
+        )
+        self.assertEqual(list(agent.tools), ["read_skill"])
+
+    async def test_skill_tool_survives_serialization_roundtrip(self):
+        root = self._make_skills_root()
+        agent = FunctionCallingAgent(
+            language_model=LanguageModel(model="ollama/mistral"),
+            skills=[root],
+        )
+        config = agent.get_config()
+        # Built-ins are not serialized with the user tools...
+        self.assertEqual(config["tools"], [])
+        # ...but rebuild from the `skills` config on reload.
+        reloaded = FunctionCallingAgent.from_config(config)
+        self.assertIn("read_skill", reloaded.tools)

--- a/synalinks/src/modules/agents/utils/skills_utils.py
+++ b/synalinks/src/modules/agents/utils/skills_utils.py
@@ -305,11 +305,16 @@ def build_read_skill_tool(roots, *, max_chars: int = 50_000):
 
     The ``<available_skills>`` block surfaces only each skill's name and
     description (level 1 of progressive disclosure); the spec assumes the
-    agent reads the rest "through its own file tools". A tool-calling agent
+    agent reads the rest through its own file tools. A tool-calling agent
     whose tools are domain tools (SQL, retrieval, ...) has none — its skills
     would be advertised but unreadable. This tool completes the disclosure
-    chain for those agents: level 2 (the ``SKILL.md`` body) and level 3
-    (bundled ``references/`` / ``assets/`` files) on demand.
+    chain for those agents, with the activation shape the ecosystem settled
+    on (Claude Code's Skill tool, the Claude API's container skills):
+    **one name-like argument**. The bare skill name returns the ``SKILL.md``
+    body plus the bundled file listing (level 2 — activation); the name
+    prefixing one of the relative paths skills use to reference their own
+    files (``pdf-processing/references/api.md``) returns that bundled file
+    (level 3).
 
     Reads are confined to the discovered skill directories: the requested
     path is resolved and must stay inside the skill's own directory, so
@@ -335,48 +340,53 @@ def build_read_skill_tool(roots, *, max_chars: int = 50_000):
 
     resolved = list(roots or [])
 
-    async def read_skill(name: str, file: str) -> dict:
-        """Read an installed Agent Skill's instructions or a bundled file.
+    async def read_skill(skill: str) -> dict:
+        """Read an installed Agent Skill.
 
         The available skills (name + description) are listed in the
         <available_skills> block of your context; this tool returns the rest
-        on demand. Read a skill's instructions BEFORE following it, and read
-        the bundled files its instructions point to.
+        on demand. Read a skill BEFORE following it. When its instructions
+        reference a bundled file, read that file the same way, prefixing the
+        skill name to the file's relative path.
 
         Args:
-            name (str): The skill to read — its `name` from
-                <available_skills>, e.g. 'pdf-processing'.
-            file (str): Pass 'SKILL.md' (or an empty string) for the skill's
-                instructions. To read a bundled file the instructions mention,
-                pass its relative path, e.g. 'references/api.md'.
+            skill (str): The skill name from <available_skills>
+                (e.g. 'pdf-processing') to read its instructions — the
+                response also lists the skill's bundled files. Or a bundled
+                file the instructions mention, as the skill name followed by
+                the file's relative path (e.g.
+                'pdf-processing/references/api.md').
         """
+        name, _, relative = (skill or "").strip().strip("/").partition("/")
         skill_dirs = {d.name: d for d in discover_skills_in_roots(resolved)}
-        skill_dir = skill_dirs.get((name or "").strip())
+        skill_dir = skill_dirs.get(name)
         if skill_dir is None:
             return {
                 "error": f"Unknown skill {name!r}.",
                 "available_skills": sorted(skill_dirs),
             }
-        relative = (file or "").strip() or "SKILL.md"
+        relative = relative or "SKILL.md"
         root = skill_dir.resolve()
         target = (root / relative).resolve()
         if root != target and root not in target.parents:
             return {
                 "error": (
-                    f"{file!r} is outside the {name!r} skill directory; only "
+                    f"{skill!r} is outside the {name!r} skill directory; only "
                     f"the skill's own files can be read."
                 )
             }
+        files = sorted(str(p.relative_to(root)) for p in root.rglob("*") if p.is_file())
         if not target.is_file():
-            available = sorted(
-                str(p.relative_to(root)) for p in root.rglob("*") if p.is_file()
-            )
             return {
                 "error": f"No file {relative!r} in skill {name!r}.",
-                "available_files": available,
+                "available_files": files,
             }
         content = target.read_text(encoding="utf-8", errors="replace")
-        report = {"skill": skill_dir.name, "file": relative}
+        report = {"skill": name, "file": relative}
+        if relative == "SKILL.md" and len(files) > 1:
+            # Activation also surfaces what else the skill bundles, so the
+            # agent knows what it can read next (level 3).
+            report["files"] = files
         if len(content) > max_chars:
             report["note"] = (
                 f"Truncated to the first {max_chars} of {len(content)} characters."

--- a/synalinks/src/modules/agents/utils/skills_utils.py
+++ b/synalinks/src/modules/agents/utils/skills_utils.py
@@ -68,6 +68,8 @@ __all__ = [
     "discover_skills_in_roots",
     "resolve_skills_paths",
     "skills_prompt",
+    "READ_SKILL_TOOL_NAME",
+    "build_read_skill_tool",
 ]
 
 
@@ -291,3 +293,96 @@ def skills_prompt(skill_dirs, *, root: Optional[str] = None) -> str:
         ]
     lines.append("</available_skills>")
     return "\n".join(lines)
+
+
+#: The reserved name of the built-in skill-reading tool (see
+#: `build_read_skill_tool`).
+READ_SKILL_TOOL_NAME = "read_skill"
+
+
+def build_read_skill_tool(roots, *, max_chars: int = 50_000):
+    """Build the built-in ``read_skill`` tool over Agent Skill *root* dirs.
+
+    The ``<available_skills>`` block surfaces only each skill's name and
+    description (level 1 of progressive disclosure); the spec assumes the
+    agent reads the rest "through its own file tools". A tool-calling agent
+    whose tools are domain tools (SQL, retrieval, ...) has none — its skills
+    would be advertised but unreadable. This tool completes the disclosure
+    chain for those agents: level 2 (the ``SKILL.md`` body) and level 3
+    (bundled ``references/`` / ``assets/`` files) on demand.
+
+    Reads are confined to the discovered skill directories: the requested
+    path is resolved and must stay inside the skill's own directory, so
+    neither ``..`` traversal nor absolute paths nor symlinks escaping the
+    skill can reach anything else. Errors come back as observations (an
+    ``"error"`` key with the available names/files), never as exceptions —
+    a wrong guess costs the agent one round, not the run.
+
+    Args:
+        roots: Skill root directories, as accepted by `discover_skills_in_roots`
+            (each root holds ``<name>/SKILL.md`` folders; first root wins on a
+            shared name — matching what the listing shows).
+        max_chars: Truncation budget for a returned file, so a large bundled
+            asset cannot flood the context window.
+
+    Returns:
+        The ``read_skill`` `Tool`.
+    """
+    # Deferred: `Tool` builds on `Module`, and importing it at module scope
+    # would cycle through `modules/__init__` while `modules.agents.utils` is
+    # itself being imported.
+    from synalinks.src.modules.core.tool import Tool
+
+    resolved = list(roots or [])
+
+    async def read_skill(name: str, file: str) -> dict:
+        """Read an installed Agent Skill's instructions or a bundled file.
+
+        The available skills (name + description) are listed in the
+        <available_skills> block of your context; this tool returns the rest
+        on demand. Read a skill's instructions BEFORE following it, and read
+        the bundled files its instructions point to.
+
+        Args:
+            name (str): The skill to read — its `name` from
+                <available_skills>, e.g. 'pdf-processing'.
+            file (str): Pass 'SKILL.md' (or an empty string) for the skill's
+                instructions. To read a bundled file the instructions mention,
+                pass its relative path, e.g. 'references/api.md'.
+        """
+        skill_dirs = {d.name: d for d in discover_skills_in_roots(resolved)}
+        skill_dir = skill_dirs.get((name or "").strip())
+        if skill_dir is None:
+            return {
+                "error": f"Unknown skill {name!r}.",
+                "available_skills": sorted(skill_dirs),
+            }
+        relative = (file or "").strip() or "SKILL.md"
+        root = skill_dir.resolve()
+        target = (root / relative).resolve()
+        if root != target and root not in target.parents:
+            return {
+                "error": (
+                    f"{file!r} is outside the {name!r} skill directory; only "
+                    f"the skill's own files can be read."
+                )
+            }
+        if not target.is_file():
+            available = sorted(
+                str(p.relative_to(root)) for p in root.rglob("*") if p.is_file()
+            )
+            return {
+                "error": f"No file {relative!r} in skill {name!r}.",
+                "available_files": available,
+            }
+        content = target.read_text(encoding="utf-8", errors="replace")
+        report = {"skill": skill_dir.name, "file": relative}
+        if len(content) > max_chars:
+            report["note"] = (
+                f"Truncated to the first {max_chars} of {len(content)} characters."
+            )
+            content = content[:max_chars]
+        report["content"] = content
+        return report
+
+    return Tool(read_skill, name=READ_SKILL_TOOL_NAME)

--- a/synalinks/src/modules/agents/utils/skills_utils.py
+++ b/synalinks/src/modules/agents/utils/skills_utils.py
@@ -253,21 +253,31 @@ def discover_skills_in_roots(roots, *, strict: bool = False) -> List[Path]:
     return sorted(seen.values(), key=lambda d: d.name)
 
 
-def skills_prompt(skill_dirs, *, root: Optional[str] = None) -> str:
+def skills_prompt(
+    skill_dirs, *, root: Optional[str] = None, locations: bool = True
+) -> str:
     """Render the ``<available_skills>`` prompt block (Agent Skills *level 1*).
 
     ``skill_dirs`` is an iterable of skill directories (as from `discover_skills`
-    / `discover_skills_in_roots`). Without ``root`` this delegates to
+    / `discover_skills_in_roots`). By default this delegates to
     ``skills_ref.to_prompt``: the exact XML Anthropic recommends, one
     ``<skill>`` per entry with ``<name>`` / ``<description>`` / ``<location>``
-    (the absolute path to ``SKILL.md``). ``root`` overrides the ``<location>``
-    prefix (e.g. the skills directory as the *sandbox* sees it, when the host
-    path differs), a remap ``skills_ref.to_prompt`` cannot do, so that case is
-    rendered locally to byte-identical XML using ``skills_ref.read_properties``
-    for each skill's name / description.
+    (the absolute path to ``SKILL.md``). Two adjustments ``skills_ref`` cannot
+    do are rendered locally to otherwise-identical XML:
+
+    - ``root`` overrides the ``<location>`` prefix (e.g. the skills directory
+      as the *sandbox* sees it, when the host path differs);
+    - ``locations=False`` omits ``<location>`` entirely — for agents that
+      read skills **by name** through the built-in ``read_skill`` tool, where
+      storage is internal and a filesystem path would only leak an
+      implementation detail (and invite the model to ask for paths).
     """
     skill_dirs = [Path(d) for d in skill_dirs]
-    if not root:
+    if root and not locations:
+        raise ValueError(
+            "`root` overrides <location>; it cannot be combined with locations=False."
+        )
+    if not root and locations:
         return to_prompt(skill_dirs)
 
     import html
@@ -277,7 +287,6 @@ def skills_prompt(skill_dirs, *, root: Optional[str] = None) -> str:
     lines = ["<available_skills>"]
     for skill_dir in skill_dirs:
         props = read_properties(skill_dir)
-        location = f"{root.rstrip('/')}/{skill_dir.name}/SKILL.md"
         lines += [
             "<skill>",
             "<name>",
@@ -286,11 +295,14 @@ def skills_prompt(skill_dirs, *, root: Optional[str] = None) -> str:
             "<description>",
             html.escape(props.description),
             "</description>",
-            "<location>",
-            location,
-            "</location>",
-            "</skill>",
         ]
+        if locations:
+            lines += [
+                "<location>",
+                f"{root.rstrip('/')}/{skill_dir.name}/SKILL.md",
+                "</location>",
+            ]
+        lines.append("</skill>")
     lines.append("</available_skills>")
     return "\n".join(lines)
 
@@ -307,28 +319,25 @@ def build_read_skill_tool(roots, *, max_chars: int = 50_000):
     description (level 1 of progressive disclosure); the spec assumes the
     agent reads the rest through its own file tools. A tool-calling agent
     whose tools are domain tools (SQL, retrieval, ...) has none — its skills
-    would be advertised but unreadable. This tool completes the disclosure
-    chain for those agents, with the activation shape the ecosystem settled
-    on (Claude Code's Skill tool, the Claude API's container skills):
-    **one name-like argument**. The bare skill name returns the ``SKILL.md``
-    body plus the bundled file listing (level 2 — activation); the name
-    prefixing one of the relative paths skills use to reference their own
-    files (``pdf-processing/references/api.md``) returns that bundled file
-    (level 3).
+    would be advertised but unreadable. This tool completes activation
+    (level 2) with the shape the ecosystem settled on (Claude Code's Skill
+    tool, the Claude API's container skills): **by name, and by name only**.
+    The skill's name is its whole address — where and how the skill is
+    stored stays internal, so no filesystem is exposed to the model (and
+    none needs to exist: a future backing could be a registry or an
+    archive). Bundled ``references/``/``scripts/`` files (level 3) remain
+    the province of agents with real file tools.
 
-    Reads are confined to the discovered skill directories: the requested
-    path is resolved and must stay inside the skill's own directory, so
-    neither ``..`` traversal nor absolute paths nor symlinks escaping the
-    skill can reach anything else. Errors come back as observations (an
-    ``"error"`` key with the available names/files), never as exceptions —
-    a wrong guess costs the agent one round, not the run.
+    Errors come back as observations (an ``"error"`` key with the available
+    skill names), never as exceptions — a wrong guess costs the agent one
+    round, not the run.
 
     Args:
         roots: Skill root directories, as accepted by `discover_skills_in_roots`
             (each root holds ``<name>/SKILL.md`` folders; first root wins on a
             shared name — matching what the listing shows).
-        max_chars: Truncation budget for a returned file, so a large bundled
-            asset cannot flood the context window.
+        max_chars: Truncation budget for a returned body, so an oversized
+            skill cannot flood the context window.
 
     Returns:
         The ``read_skill`` `Tool`.
@@ -340,53 +349,26 @@ def build_read_skill_tool(roots, *, max_chars: int = 50_000):
 
     resolved = list(roots or [])
 
-    async def read_skill(skill: str) -> dict:
-        """Read an installed Agent Skill.
+    async def read_skill(name: str) -> dict:
+        """Read an installed Agent Skill's full instructions.
 
         The available skills (name + description) are listed in the
-        <available_skills> block of your context; this tool returns the rest
-        on demand. Read a skill BEFORE following it. When its instructions
-        reference a bundled file, read that file the same way, prefixing the
-        skill name to the file's relative path.
+        <available_skills> block of your context; this tool loads a skill's
+        complete instructions. Read a skill BEFORE following it.
 
         Args:
-            skill (str): The skill name from <available_skills>
-                (e.g. 'pdf-processing') to read its instructions — the
-                response also lists the skill's bundled files. Or a bundled
-                file the instructions mention, as the skill name followed by
-                the file's relative path (e.g.
-                'pdf-processing/references/api.md').
+            name (str): The skill name from <available_skills>,
+                e.g. 'pdf-processing'.
         """
-        name, _, relative = (skill or "").strip().strip("/").partition("/")
         skill_dirs = {d.name: d for d in discover_skills_in_roots(resolved)}
-        skill_dir = skill_dirs.get(name)
+        skill_dir = skill_dirs.get((name or "").strip())
         if skill_dir is None:
             return {
                 "error": f"Unknown skill {name!r}.",
                 "available_skills": sorted(skill_dirs),
             }
-        relative = relative or "SKILL.md"
-        root = skill_dir.resolve()
-        target = (root / relative).resolve()
-        if root != target and root not in target.parents:
-            return {
-                "error": (
-                    f"{skill!r} is outside the {name!r} skill directory; only "
-                    f"the skill's own files can be read."
-                )
-            }
-        files = sorted(str(p.relative_to(root)) for p in root.rglob("*") if p.is_file())
-        if not target.is_file():
-            return {
-                "error": f"No file {relative!r} in skill {name!r}.",
-                "available_files": files,
-            }
-        content = target.read_text(encoding="utf-8", errors="replace")
-        report = {"skill": name, "file": relative}
-        if relative == "SKILL.md" and len(files) > 1:
-            # Activation also surfaces what else the skill bundles, so the
-            # agent knows what it can read next (level 3).
-            report["files"] = files
+        content = (skill_dir / "SKILL.md").read_text(encoding="utf-8", errors="replace")
+        report = {"skill": skill_dir.name}
         if len(content) > max_chars:
             report["note"] = (
                 f"Truncated to the first {max_chars} of {len(content)} characters."

--- a/synalinks/src/modules/agents/utils/skills_utils_test.py
+++ b/synalinks/src/modules/agents/utils/skills_utils_test.py
@@ -293,30 +293,31 @@ class BuildReadSkillToolTest(testing.TestCase):
             f.write("# API\nDetails here.")
         return root
 
-    async def test_reads_skill_body_by_default(self):
+    async def test_bare_name_reads_body_and_lists_bundled_files(self):
         tool = build_read_skill_tool([self._make_root()])
         self.assertEqual(tool.name, READ_SKILL_TOOL_NAME)
-        for file in ("", "SKILL.md"):
-            report = await _json(tool)(name="pdf-processing", file=file)
-            self.assertEqual(report["skill"], "pdf-processing")
-            self.assertEqual(report["file"], "SKILL.md")
-            self.assertIn("pdfplumber", report["content"])
+        report = await _json(tool)(skill="pdf-processing")
+        self.assertEqual(report["skill"], "pdf-processing")
+        self.assertEqual(report["file"], "SKILL.md")
+        self.assertIn("pdfplumber", report["content"])
+        self.assertEqual(report["files"], ["SKILL.md", "references/api.md"])
 
-    async def test_reads_bundled_reference_file(self):
+    async def test_name_slash_path_reads_bundled_file(self):
         tool = build_read_skill_tool([self._make_root()])
-        report = await _json(tool)(name="pdf-processing", file="references/api.md")
+        report = await _json(tool)(skill="pdf-processing/references/api.md")
         self.assertEqual(report["file"], "references/api.md")
         self.assertIn("Details here.", report["content"])
+        self.assertNotIn("files", report)
 
     async def test_unknown_skill_lists_available(self):
         tool = build_read_skill_tool([self._make_root()])
-        report = await _json(tool)(name="nope", file="")
+        report = await _json(tool)(skill="nope")
         self.assertIn("error", report)
         self.assertEqual(report["available_skills"], ["pdf-processing"])
 
     async def test_missing_file_lists_available_files(self):
         tool = build_read_skill_tool([self._make_root()])
-        report = await _json(tool)(name="pdf-processing", file="references/missing.md")
+        report = await _json(tool)(skill="pdf-processing/references/missing.md")
         self.assertIn("error", report)
         self.assertIn("SKILL.md", report["available_files"])
         self.assertIn("references/api.md", report["available_files"])
@@ -326,15 +327,18 @@ class BuildReadSkillToolTest(testing.TestCase):
         with open(os.path.join(root, "secret.txt"), "w") as f:
             f.write("nope")
         tool = build_read_skill_tool([root])
-        for path in ("../secret.txt", "/etc/hostname", "references/../../secret.txt"):
-            report = await _json(tool)(name="pdf-processing", file=path)
+        for path in (
+            "pdf-processing/../secret.txt",
+            "pdf-processing/references/../../secret.txt",
+        ):
+            report = await _json(tool)(skill=path)
             self.assertIn("error", report)
             self.assertNotIn("content", report)
 
     async def test_truncates_large_files(self):
         root = self._make_root()
         tool = build_read_skill_tool([root], max_chars=10)
-        report = await _json(tool)(name="pdf-processing", file="references/api.md")
+        report = await _json(tool)(skill="pdf-processing/references/api.md")
         self.assertEqual(len(report["content"]), 10)
         self.assertIn("note", report)
 
@@ -343,5 +347,5 @@ class BuildReadSkillToolTest(testing.TestCase):
         with open(os.path.join(second, "pdf-processing", "SKILL.md"), "w") as f:
             f.write(_MINIMAL.replace("hello", "pdf-processing"))
         tool = build_read_skill_tool([first, second])
-        report = await _json(tool)(name="pdf-processing", file="")
+        report = await _json(tool)(skill="pdf-processing")
         self.assertIn("pdfplumber", report["content"])

--- a/synalinks/src/modules/agents/utils/skills_utils_test.py
+++ b/synalinks/src/modules/agents/utils/skills_utils_test.py
@@ -259,6 +259,18 @@ class SkillsPromptTest(testing.TestCase):
         self.assertIn("<description>\nHandle PDFs.\n</description>", out)
         self.assertIn(f"<location>\n{d}/SKILL.md\n</location>", out)
 
+    def test_locations_false_omits_location(self):
+        d = self._write("pdf", "---\nname: pdf\ndescription: Handle PDFs.\n---\n")
+        out = skills_prompt([d], locations=False)
+        self.assertIn("<name>\npdf\n</name>", out)
+        self.assertIn("<description>\nHandle PDFs.\n</description>", out)
+        self.assertNotIn("<location>", out)
+
+    def test_root_cannot_combine_with_locations_false(self):
+        d = self._write("pdf", "---\nname: pdf\ndescription: Handle PDFs.\n---\n")
+        with self.assertRaises(ValueError):
+            skills_prompt([d], root="/work/skills", locations=False)
+
     def test_root_overrides_location_prefix(self):
         d = self._write("pdf", _MINIMAL.replace("hello", "pdf"))
         out = skills_prompt([d], root="/work/skills")
@@ -293,52 +305,36 @@ class BuildReadSkillToolTest(testing.TestCase):
             f.write("# API\nDetails here.")
         return root
 
-    async def test_bare_name_reads_body_and_lists_bundled_files(self):
+    async def test_reads_skill_body_by_name(self):
         tool = build_read_skill_tool([self._make_root()])
         self.assertEqual(tool.name, READ_SKILL_TOOL_NAME)
-        report = await _json(tool)(skill="pdf-processing")
+        report = await _json(tool)(name="pdf-processing")
         self.assertEqual(report["skill"], "pdf-processing")
-        self.assertEqual(report["file"], "SKILL.md")
         self.assertIn("pdfplumber", report["content"])
-        self.assertEqual(report["files"], ["SKILL.md", "references/api.md"])
 
-    async def test_name_slash_path_reads_bundled_file(self):
+    async def test_nothing_path_shaped_in_the_report(self):
+        # The name is the whole address: storage stays internal, so no path
+        # or file listing leaks into the observation.
         tool = build_read_skill_tool([self._make_root()])
-        report = await _json(tool)(skill="pdf-processing/references/api.md")
-        self.assertEqual(report["file"], "references/api.md")
-        self.assertIn("Details here.", report["content"])
-        self.assertNotIn("files", report)
+        report = await _json(tool)(name="pdf-processing")
+        self.assertEqual(sorted(report), ["content", "skill"])
 
     async def test_unknown_skill_lists_available(self):
         tool = build_read_skill_tool([self._make_root()])
-        report = await _json(tool)(skill="nope")
+        report = await _json(tool)(name="nope")
         self.assertIn("error", report)
         self.assertEqual(report["available_skills"], ["pdf-processing"])
 
-    async def test_missing_file_lists_available_files(self):
+    async def test_path_shaped_names_are_unknown(self):
         tool = build_read_skill_tool([self._make_root()])
-        report = await _json(tool)(skill="pdf-processing/references/missing.md")
-        self.assertIn("error", report)
-        self.assertIn("SKILL.md", report["available_files"])
-        self.assertIn("references/api.md", report["available_files"])
-
-    async def test_rejects_paths_outside_the_skill(self):
-        root = self._make_root()
-        with open(os.path.join(root, "secret.txt"), "w") as f:
-            f.write("nope")
-        tool = build_read_skill_tool([root])
-        for path in (
-            "pdf-processing/../secret.txt",
-            "pdf-processing/references/../../secret.txt",
-        ):
-            report = await _json(tool)(skill=path)
+        for name in ("pdf-processing/references/api.md", "../pdf-processing"):
+            report = await _json(tool)(name=name)
             self.assertIn("error", report)
             self.assertNotIn("content", report)
 
-    async def test_truncates_large_files(self):
-        root = self._make_root()
-        tool = build_read_skill_tool([root], max_chars=10)
-        report = await _json(tool)(skill="pdf-processing/references/api.md")
+    async def test_truncates_large_bodies(self):
+        tool = build_read_skill_tool([self._make_root()], max_chars=10)
+        report = await _json(tool)(name="pdf-processing")
         self.assertEqual(len(report["content"]), 10)
         self.assertIn("note", report)
 
@@ -347,5 +343,5 @@ class BuildReadSkillToolTest(testing.TestCase):
         with open(os.path.join(second, "pdf-processing", "SKILL.md"), "w") as f:
             f.write(_MINIMAL.replace("hello", "pdf-processing"))
         tool = build_read_skill_tool([first, second])
-        report = await _json(tool)(skill="pdf-processing")
+        report = await _json(tool)(name="pdf-processing")
         self.assertIn("pdfplumber", report["content"])

--- a/synalinks/src/modules/agents/utils/skills_utils_test.py
+++ b/synalinks/src/modules/agents/utils/skills_utils_test.py
@@ -9,9 +9,11 @@ import os
 import tempfile
 
 from synalinks.src import testing
+from synalinks.src.modules.agents.utils.skills_utils import READ_SKILL_TOOL_NAME
 from synalinks.src.modules.agents.utils.skills_utils import Skill
 from synalinks.src.modules.agents.utils.skills_utils import SkillParseError
 from synalinks.src.modules.agents.utils.skills_utils import SkillValidationError
+from synalinks.src.modules.agents.utils.skills_utils import build_read_skill_tool
 from synalinks.src.modules.agents.utils.skills_utils import discover_skills
 from synalinks.src.modules.agents.utils.skills_utils import find_skill_md
 from synalinks.src.modules.agents.utils.skills_utils import load_skill
@@ -267,3 +269,79 @@ class SkillsPromptTest(testing.TestCase):
         d = self._write("x", "---\nname: x\ndescription: a & b <c>\n---\n")
         out = skills_prompt([d])
         self.assertIn("a &amp; b &lt;c&gt;", out)
+
+
+def _json(tool):
+    """Call a tool and return its plain-dict result (tools wrap dicts in a
+    JsonDataModel)."""
+
+    async def call(**kwargs):
+        result = await tool(**kwargs)
+        return result.get_json() if hasattr(result, "get_json") else result
+
+    return call
+
+
+class BuildReadSkillToolTest(testing.TestCase):
+    def _make_root(self):
+        root = tempfile.mkdtemp()
+        skill_dir = os.path.join(root, "pdf-processing")
+        os.makedirs(os.path.join(skill_dir, "references"))
+        with open(os.path.join(skill_dir, "SKILL.md"), "w") as f:
+            f.write(_FULL)
+        with open(os.path.join(skill_dir, "references", "api.md"), "w") as f:
+            f.write("# API\nDetails here.")
+        return root
+
+    async def test_reads_skill_body_by_default(self):
+        tool = build_read_skill_tool([self._make_root()])
+        self.assertEqual(tool.name, READ_SKILL_TOOL_NAME)
+        for file in ("", "SKILL.md"):
+            report = await _json(tool)(name="pdf-processing", file=file)
+            self.assertEqual(report["skill"], "pdf-processing")
+            self.assertEqual(report["file"], "SKILL.md")
+            self.assertIn("pdfplumber", report["content"])
+
+    async def test_reads_bundled_reference_file(self):
+        tool = build_read_skill_tool([self._make_root()])
+        report = await _json(tool)(name="pdf-processing", file="references/api.md")
+        self.assertEqual(report["file"], "references/api.md")
+        self.assertIn("Details here.", report["content"])
+
+    async def test_unknown_skill_lists_available(self):
+        tool = build_read_skill_tool([self._make_root()])
+        report = await _json(tool)(name="nope", file="")
+        self.assertIn("error", report)
+        self.assertEqual(report["available_skills"], ["pdf-processing"])
+
+    async def test_missing_file_lists_available_files(self):
+        tool = build_read_skill_tool([self._make_root()])
+        report = await _json(tool)(name="pdf-processing", file="references/missing.md")
+        self.assertIn("error", report)
+        self.assertIn("SKILL.md", report["available_files"])
+        self.assertIn("references/api.md", report["available_files"])
+
+    async def test_rejects_paths_outside_the_skill(self):
+        root = self._make_root()
+        with open(os.path.join(root, "secret.txt"), "w") as f:
+            f.write("nope")
+        tool = build_read_skill_tool([root])
+        for path in ("../secret.txt", "/etc/hostname", "references/../../secret.txt"):
+            report = await _json(tool)(name="pdf-processing", file=path)
+            self.assertIn("error", report)
+            self.assertNotIn("content", report)
+
+    async def test_truncates_large_files(self):
+        root = self._make_root()
+        tool = build_read_skill_tool([root], max_chars=10)
+        report = await _json(tool)(name="pdf-processing", file="references/api.md")
+        self.assertEqual(len(report["content"]), 10)
+        self.assertIn("note", report)
+
+    async def test_first_root_wins_for_shared_names(self):
+        first, second = self._make_root(), self._make_root()
+        with open(os.path.join(second, "pdf-processing", "SKILL.md"), "w") as f:
+            f.write(_MINIMAL.replace("hello", "pdf-processing"))
+        tool = build_read_skill_tool([first, second])
+        report = await _json(tool)(name="pdf-processing", file="")
+        self.assertIn("pdfplumber", report["content"])


### PR DESCRIPTION
## Problem

`skills=` roots give an agent the `<available_skills>` listing (level 1 of progressive disclosure), but the spec assumes the agent reads `SKILL.md` bodies through its own file/bash tools. A `FunctionCallingAgent` whose tools are domain tools (SQL, retrieval, a semantic layer, ...) has no file access — its skills are advertised but **unreadable**, and every application has to hand-roll a reader tool. (Found while building Synalemma's analyst agent, which hit exactly this gap.)

## Design

Surveyed how the ecosystem consumes skills before picking the shape:

- **Claude Code's Skill tool**: invocation by **name only**; the full `SKILL.md` body loads into context; supporting files are read afterwards with the agent's general file tools.
- **Claude API Agent Skills**: skills are mounted into the code-execution container; the model reads everything with bash. No path-taking skill tool.
- **agentskills.io spec**: prescribes no mechanism — only the three disclosure levels.

The principle this PR lands on: **the name is the whole address; storage is internal.**

- `read_skill(name)` returns the `SKILL.md` body. Nothing path-shaped goes in or out — no filesystem needs to be mounted or revealed to the model, so a future backing could be a registry or an archive rather than a directory.
- The `<available_skills>` listing the agent sees is rendered **without `<location>`** (new `locations=False` mode on `skills_prompt`): a path there would only leak an implementation detail and invite the model to ask for paths.
- Bundled `references/`/`scripts/` files (level 3) remain the province of agents with real file tools; the sandbox `root` override keeps its `<location>` rendering for exactly those.

## Change

Setting `skills=` adds the built-in **`read_skill(name)`** tool:

- Wrong guesses come back as observations (`error` + available skill names), never exceptions — a miss costs one round, not the run.
- Oversized bodies truncate (`max_chars`, default 50k).
- **Precedence**: an existing tool named `read_skill` — from a subclass's `_get_builtin_tools` or the `tools` argument — wins over the built-in.
- **Serialization**: like every built-in, not serialized with user tools; rebuilds from the `skills` config on reload (roundtrip-tested).
- Side effect worth noting: with `skills=` set, the built-in satisfies `_requires_tools`, so a skills-only agent can be constructed without user tools.

## Implementation

- `skills_utils.build_read_skill_tool(roots, *, max_chars)` + `READ_SKILL_TOOL_NAME` (deferred `Tool` import to avoid the modules import cycle).
- `skills_utils.skills_prompt(..., locations=False)` — local rendering without `<location>`; combining it with `root` raises.
- `FunctionCallingAgent._skills_tools(builtin_tools)` appends the built-in next to the `_get_builtin_tools()` result before `merge_tools`; `read_skills()` renders the listing path-free; the `skills` docstring documents the behavior.

## Tests

- `skills_utils_test.py::BuildReadSkillToolTest` — body read by name, nothing path-shaped in the report, path-shaped names rejected as unknown, unknown-skill observation, truncation, first-root-wins.
- `skills_utils_test.py::SkillsPromptTest` — `locations=False` omits `<location>`; `root` + `locations=False` raises.
- `function_calling_agent_test.py::SkillsToolWiringTest` — tool added with `skills=`, absent without, user override wins, skills-only construction, path-free listing, config roundtrip.

`pytest synalinks/src/modules/agents/` — 185 passed. `ruff` + `black -l 90` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)