### PR TITLE
fix(language-models): emit plain containers in wire tool declarations

### DIFF
--- a/synalinks/src/modules/language_models/language_model.py
+++ b/synalinks/src/modules/language_models/language_model.py
@@ -153,12 +153,44 @@ def _message_to_wire(message):
     return wire
 
 
+def _plain_containers(value):
+    """Rebuild `value` out of plain `dict`/`list` containers.
+
+    A `Tool` assembles its schema from its own attributes, so the module's
+    `Tracker` has already wrapped them as `TrackedDict`/`TrackedList`. Each
+    wrapper holds a reference back to that tracker, whose `config` reaches every
+    variable and submodule of the owning program — so a tracked container is not
+    a leaf, it is a handle on the whole module graph.
+
+    That matters because a provider may copy what it is handed: litellm's
+    Anthropic handler runs `copy.deepcopy(optional_params)` before translating
+    them. Deep-copying a tracked container therefore walks the module graph, and
+    the graph has cycles (tracker -> store -> module -> tracked attribute ->
+    tracker). Cycles make `copy` hand back a half-built `Tracker` from its memo,
+    and `TrackedDict.__setitem__` then dereferences `tracker.config` on it,
+    raising `'Tracker' object has no attribute 'config'` — which surfaced as an
+    `APIConnectionError` on every Anthropic tool-calling request.
+
+    Nothing on the wire needs the tracking behaviour, so the converters emit
+    plain containers. This also keeps a provider-side copy proportional to the
+    schema rather than to the program.
+    """
+    if isinstance(value, dict):
+        return {key: _plain_containers(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_plain_containers(item) for item in value]
+    return value
+
+
 def _tool_to_wire(tool):
     """Convert a synalinks Tool to an OpenAI Chat Completions wire-format
     tool declaration dict."""
     if not isinstance(tool, Tool):
         raise TypeError(f"Expected synalinks.modules.Tool, got {type(tool).__name__}")
-    function = {"name": tool.name, "parameters": tool.get_tool_schema()}
+    function = {
+        "name": tool.name,
+        "parameters": _plain_containers(tool.get_tool_schema()),
+    }
     if tool.description:
         function["description"] = tool.description
     return {"type": "function", "function": function}

--- a/synalinks/src/modules/language_models/language_model_test.py
+++ b/synalinks/src/modules/language_models/language_model_test.py
@@ -1,6 +1,7 @@
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
 import base64
+import copy
 import os
 from unittest.mock import patch
 
@@ -12,6 +13,7 @@ from litellm.types.utils import PromptTokensDetailsWrapper
 from litellm.types.utils import ServerToolUse
 from litellm.types.utils import Usage
 
+import synalinks
 from synalinks.src import testing
 from synalinks.src.backend import Audio
 from synalinks.src.backend import ChatMessage
@@ -20,7 +22,9 @@ from synalinks.src.backend import ChatRole
 from synalinks.src.backend import DataModel
 from synalinks.src.backend import Image
 from synalinks.src.backend.common.op_scope import _OP_SCOPE
+from synalinks.src.modules.core.tool import Tool
 from synalinks.src.modules.language_models import LanguageModel
+from synalinks.src.modules.language_models.language_model import _tool_to_wire
 
 _SAMPLE_IMAGE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -795,3 +799,70 @@ class LMFileCacheTest(testing.TestCase):
         restored = LanguageModel.from_config(config)
         self.assertEqual(restored.cache_dir, cache_dir)
         self.assertIsNotNone(restored._file_cache)
+
+
+class ToolWireFormatTest(testing.TestCase):
+    """A wire-format tool declaration must be plain, self-contained data.
+
+    A `Tool` builds its schema from its own attributes, so the module's
+    `Tracker` has wrapped them as `TrackedDict`/`TrackedList`. Each wrapper
+    points back at that tracker, and through it at every variable and submodule
+    of the owning program. litellm's Anthropic handler deepcopies the optional
+    params it is given, so a leaked wrapper made it copy the whole module graph
+    — and the graph's cycles left the copied tracker half-built, failing every
+    tool-calling request on that provider with `'Tracker' object has no
+    attribute 'config'`.
+    """
+
+    @staticmethod
+    def _tool():
+        @synalinks.saving.register_synalinks_serializable()
+        async def search(query: str, limit: int):
+            """Search the index.
+
+            Args:
+                query (str): What to look for.
+                limit (int): How many results to return.
+            """
+            return {"results": []}
+
+        return Tool(func=search)
+
+    def test_wire_declaration_uses_builtin_containers(self):
+        wire = _tool_to_wire(self._tool())
+
+        def assert_plain(value, path):
+            if isinstance(value, dict):
+                self.assertIs(type(value), dict, f"{path} is {type(value).__name__}")
+                for key, item in value.items():
+                    assert_plain(item, f"{path}.{key}")
+            elif isinstance(value, list):
+                self.assertIs(type(value), list, f"{path} is {type(value).__name__}")
+                for index, item in enumerate(value):
+                    assert_plain(item, f"{path}[{index}]")
+
+        assert_plain(wire, "tool")
+
+    def test_wire_declaration_holds_no_tracker_reference(self):
+        """No node on the wire may be a handle on the module graph."""
+        wire = _tool_to_wire(self._tool())
+        stack = [("tool", wire)]
+        while stack:
+            path, value = stack.pop()
+            self.assertFalse(
+                hasattr(value, "tracker"),
+                f"{path} carries a tracker reference into the provider payload",
+            )
+            if isinstance(value, dict):
+                stack.extend((f"{path}.{k}", v) for k, v in value.items())
+            elif isinstance(value, list):
+                stack.extend((f"{path}[{i}]", v) for i, v in enumerate(value))
+
+    def test_wire_declaration_preserves_the_schema(self):
+        wire = _tool_to_wire(self._tool())
+        parameters = wire["function"]["parameters"]
+        self.assertEqual(wire["type"], "function")
+        self.assertEqual(wire["function"]["name"], "search")
+        self.assertEqual(parameters["type"], "object")
+        self.assertEqual(set(parameters["properties"]), {"query", "limit"})
+        self.assertEqual(sorted(parameters["required"]), ["limit", "query"])


### PR DESCRIPTION
## The bug

Every tool-calling request against an `anthropic/*` model fails with:

```
litellm.APIConnectionError: 'Tracker' object has no attribute 'config'
```

After the retries are exhausted the agent gets nothing back, so
`FunctionCallingAgent` (and everything built on it) is unusable on that
provider. Other providers are unaffected, which is why this went unnoticed.

## Why

A `Tool` assembles its schema from its own attributes, so the module's
`Tracker` has already wrapped them as `TrackedDict`/`TrackedList`:

```python
>>> tool.get_tool_schema()["properties"].__class__
<class 'synalinks.src.utils.tracking.TrackedDict'>
```

Each wrapper keeps a reference to the tracker, whose `config` reaches every
variable and submodule of the owning program — so a tracked container is not a
leaf, it is a handle on the whole module graph.

`_tool_to_wire` passed those wrappers straight into the provider payload. That
is harmless for providers that forward their params as-is, but litellm's
Anthropic handler copies them first:

```python
# litellm/llms/anthropic/chat/handler.py:348
optional_params = copy.deepcopy(optional_params)
```

Deep-copying a tracked container therefore walks the module graph, and that
graph is cyclic (`tracker -> store -> module -> tracked attribute -> tracker`).
The cycle makes `copy` hand back a half-built `Tracker` from its memo, and
`TrackedDict.__setitem__` then dereferences `tracker.config` on it.

The failure needs the cycle: deep-copying a tool schema on its own succeeds,
which is why this only shows up against a real agent.

## The fix

Rebuild the schema out of plain `dict`/`list` at the wire boundary, where the
tracking behaviour is not wanted anyway. As a side effect a provider-side copy
is now bounded by the size of the schema rather than the size of the program.

## Tests

Two colocated tests, both failing before the change and passing after:

- `test_wire_declaration_uses_builtin_containers` — every container in the
  declaration is exactly `dict`/`list`.
- `test_wire_declaration_holds_no_tracker_reference` — no node in the
  declaration carries a `tracker` attribute, i.e. nothing on the wire is a
  handle on the module graph.

A third test pins that the schema itself is unchanged.

## Verification

`synalinks/src/modules/language_models/language_model_test.py` — 33 passed.

The full suite reports 123 failures on this branch, and **the same 123 on a
pristine `main` worktree** — all in `mirage_sandbox` / `deep_agent` /
`python_synthesis` / `rlm_agent`, from `TypeError: Workspace.__init__() got an
unexpected keyword argument 'fuse'` (a `mirage-ai` version mismatch, unrelated
to this change).

Reproduced end-to-end against `anthropic/claude-sonnet-5`: a
`FunctionCallingAgent` subclass that failed on every iteration before the change
now completes its tool-calling loop normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)