### PR TITLE
fix(metrics): collect sub_language_model in operational metrics

### DIFF
--- a/synalinks/src/metrics/lm_metrics.py
+++ b/synalinks/src/metrics/lm_metrics.py
@@ -41,6 +41,15 @@ _TRACKED_SUFFIXES = (
 def _collect_language_models(program):
     """Walk a program's module tree and return every unique LanguageModel
     (including those reached via the `fallback` chain), preserving order.
+
+    Checks both `language_model` and `sub_language_model`: agents such as
+    `RecursiveLanguageModelAgent` and `DeepAgent` resolve `sub_language_model`
+    to its own `LanguageModel` instance (distinct from `language_model`, even
+    when constructed from the same model identifier — see
+    `RecursiveLanguageModelAgent.__init__`) to drive recursive sub-queries /
+    subagents. Skipping it here left those calls' `cumulated_cost` counted
+    (updated unconditionally) but every token/latency operational metric
+    blind to them, since only `language_model` was ever chained.
     """
     from synalinks.src.modules.language_models import LanguageModel
 
@@ -61,6 +70,7 @@ def _collect_language_models(program):
         modules = program._flatten_modules(include_self=True, recursive=True)
     for module in modules:
         _add_chain(getattr(module, "language_model", None))
+        _add_chain(getattr(module, "sub_language_model", None))
         if isinstance(module, LanguageModel):
             _add_chain(module)
     return lms

--- a/synalinks/src/metrics/lm_metrics_test.py
+++ b/synalinks/src/metrics/lm_metrics_test.py
@@ -111,10 +111,14 @@ def _record(lm, prompt, completion, elapsed, cost, phase="inference"):
 
 
 class _FakeModule:
-    """Minimal stand-in for a Module with a `.language_model` attribute."""
+    """Minimal stand-in for a Module with `.language_model` /
+    `.sub_language_model` attributes (the latter matching
+    `RecursiveLanguageModelAgent`/`DeepAgent`, which resolve it to its own
+    `LanguageModel` instance, distinct from `.language_model`)."""
 
-    def __init__(self, lm=None, submodules=()):
+    def __init__(self, lm=None, sub_lm=None, submodules=()):
         self.language_model = lm
+        self.sub_language_model = sub_lm
         self._modules = list(submodules)
 
 
@@ -335,6 +339,41 @@ class OperationalMetricsAutoBindTest(testing.TestCase):
         lms = _collect_language_models(program)
         self.assertEqual(len(lms), 1)
         self.assertIs(lms[0], shared_lm)
+
+    def test_collect_walks_sub_language_model(self):
+        # `RecursiveLanguageModelAgent`/`DeepAgent` resolve `sub_language_model`
+        # to its own `LanguageModel` instance (distinct from `language_model`
+        # even when built from the same model identifier), to drive
+        # `llm_query`/`llm_query_batched`/subagent calls. A module exposing
+        # only `.language_model` to `_collect_language_models` left every
+        # token/latency operational metric blind to that instance's calls,
+        # even though its `cumulated_cost` (updated unconditionally,
+        # independent of this collector) was still counted correctly.
+        primary_lm = _stub_lm()
+        sub_lm = _stub_lm()
+        program = _FakeProgram(
+            modules=[_FakeModule(lm=primary_lm, sub_lm=sub_lm)]
+        )
+        lms = _collect_language_models(program)
+        ids = [id(lm) for lm in lms]
+        self.assertIn(id(primary_lm), ids)
+        self.assertIn(id(sub_lm), ids)
+        self.assertEqual(len(set(ids)), 2)
+
+    def test_bind_program_aggregates_sub_language_model_tokens(self):
+        # End-to-end version of the bug: a metric bound to a program whose
+        # only LM module exposes `sub_language_model` must still see calls
+        # recorded on it.
+        primary_lm = _stub_lm()
+        sub_lm = _stub_lm()
+        program = _FakeProgram(
+            modules=[_FakeModule(lm=primary_lm, sub_lm=sub_lm)]
+        )
+        m = TotalTokens()
+        m.bind_program(program)
+        _record(primary_lm, prompt=100, completion=20, elapsed=0.1, cost=0.001)
+        _record(sub_lm, prompt=50, completion=10, elapsed=0.1, cost=0.0005)
+        self.assertEqual(m.result(), 180)  # 120 (primary) + 60 (sub)
 
     def test_bind_program_aggregates_across_modules(self):
         lm_a = _stub_lm()


### PR DESCRIPTION
## Summary

`RecursiveLanguageModelAgent` and `DeepAgent` resolve `sub_language_model` to its own `LanguageModel` instance (distinct from `language_model`, even when built from the same model identifier), to drive `llm_query`/`llm_query_batched` and subagent dispatch.

`_collect_language_models` (in `lm_metrics.py`), which every `LMOperationalMetric` (`TotalTokens`, `InputTokens`, `OutputTokens`, `AvgLatency`, their reward/optimizer-phase siblings, etc.) binds through, only ever chained through a module's `.language_model` attribute — never `.sub_language_model`. So real, costed calls made on the sub LM were entirely invisible to every token/latency metric, while `cumulated_cost` (updated unconditionally, independent of this collector) counted them correctly.

Observed downstream in a dependent project: a `RecursiveLanguageModelAgent` task with real, non-zero API cost reporting `total_tokens == 0` in `program.evaluate()`'s metrics.

## Fix

Chain through `sub_language_model` alongside `language_model` in `_collect_language_models` — one line, `_add_chain(getattr(module, "sub_language_model", None))`.

## Test plan

- [x] New unit tests in `lm_metrics_test.py`: `test_collect_walks_sub_language_model` (the collector includes a distinct `sub_language_model` instance) and `test_bind_program_aggregates_sub_language_model_tokens` (an end-to-end `TotalTokens` bind picks up calls recorded on it). Both fail without the fix (verified via `git stash`), pass with it.
- [x] Full suite: `uv run pytest --cov-config=pyproject.toml` — 2173 passed, 9 skipped, 0 failed.
- [x] Verified against the real `RecursiveLanguageModelAgent` class directly (not just the test's fake module): constructing an agent with distinct `language_model`/`sub_language_model` instances and calling `_collect_language_models` on a program exposing it returns both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)