### PR TITLE
fix(knowledge-bases): bound LadybugAdapter's extension INSTALL with a timeout

### DIFF
--- a/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter.py
+++ b/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter.py
@@ -50,6 +50,7 @@ References:
 """
 
 import re
+import threading
 import uuid
 import warnings
 from contextlib import contextmanager
@@ -83,6 +84,15 @@ from synalinks.src.knowledge_bases.graph_database_adapters.graph_database_adapte
 from synalinks.src.modules.embedding_models import get as _get_em
 
 METRICS = ("cosine", "l2sq", "l2", "dotproduct")
+
+# `INSTALL` on an extension not already cached on disk fetches it over the
+# network; Ladybug's C++ layer runs that fetch synchronously with no timeout
+# of its own, so a stalled connection (a flaky runner, a rate-limited CDN)
+# blocks forever inside `__init__` — observed as CI jobs stuck for 20+ minutes
+# with no error, on a network hiccup completely unrelated to the code under
+# test. Bounding it here turns a hang into the same "extension unavailable"
+# warning the surrounding `except` already produces for a real failure.
+_EXTENSION_INSTALL_TIMEOUT_SECONDS = 15
 
 # Word-boundary match of any Cypher write / admin keyword. Conservative
 # on purpose: it also fires inside string literals, but read_only
@@ -482,10 +492,12 @@ class LadybugAdapter(GraphDatabaseAdapter):
 
         # Install / load extensions used by the indices below. Failures
         # surface as a warning so the adapter still opens for users who
-        # only need bare Cypher.
+        # only need bare Cypher. `INSTALL` is the one that can reach the
+        # network (see `_EXTENSION_INSTALL_TIMEOUT_SECONDS`), so it alone
+        # runs bounded; `LOAD` only touches the local cache once installed.
         for ext in ("vector", "fts", "algo"):
             try:
-                self._con.execute(f"INSTALL {ext}")
+                self._install_extension(ext)
                 self._con.execute(f"LOAD {ext}")
             except Exception as e:  # noqa: BLE001
                 warnings.warn(
@@ -497,6 +509,37 @@ class LadybugAdapter(GraphDatabaseAdapter):
             self.wipe_database()
 
         self._setup_schema()
+
+    def _install_extension(self, ext: str) -> None:
+        """Run ``INSTALL {ext}`` off-thread, bounded by a hard timeout.
+
+        Through a throwaway in-memory connection, never ``self._con``: if the
+        network stalls there is no way to cancel the call from Python, so the
+        worker thread (a daemon — it cannot block interpreter exit) keeps
+        running past the timeout. Touching the *shared* connection from that
+        abandoned thread while the caller moves on and uses it too would race.
+        `INSTALL` writes into the extensions cache DuckDB-family engines share
+        on disk, so a later ``LOAD`` on ``self._con`` still finds it once it
+        lands — this only bounds how long ``__init__`` waits for that.
+        """
+        error: Dict[str, BaseException] = {}
+
+        def _target():
+            try:
+                lb.Connection(lb.Database(":memory:")).execute(f"INSTALL {ext}")
+            except Exception as exc:  # noqa: BLE001
+                error["exc"] = exc
+
+        thread = threading.Thread(target=_target, daemon=True)
+        thread.start()
+        thread.join(timeout=_EXTENSION_INSTALL_TIMEOUT_SECONDS)
+        if thread.is_alive():
+            raise TimeoutError(
+                f"INSTALL {ext} did not complete within "
+                f"{_EXTENSION_INSTALL_TIMEOUT_SECONDS}s"
+            )
+        if "exc" in error:
+            raise error["exc"]
 
     # ------------------------------------------------------------------
     # Schema

--- a/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter.py
+++ b/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter.py
@@ -94,6 +94,13 @@ METRICS = ("cosine", "l2sq", "l2", "dotproduct")
 # warning the surrounding `except` already produces for a real failure.
 _EXTENSION_INSTALL_TIMEOUT_SECONDS = 15
 
+# Whether `INSTALL {ext}` has already succeeded (True) or failed (False) once
+# this process, keyed by extension name; unset means "not attempted yet". Same
+# idea as `_confine_smoke_cache` below: an extension's availability doesn't
+# change mid-process, so every `LadybugAdapter` past the first pays this from
+# cache instead of repeating the same network round-trip.
+_extension_install_ok: Dict[str, bool] = {}
+
 # Word-boundary match of any Cypher write / admin keyword. Conservative
 # on purpose: it also fires inside string literals, but read_only
 # queries never legitimately need these words anyway, and the false
@@ -494,14 +501,35 @@ class LadybugAdapter(GraphDatabaseAdapter):
         # surface as a warning so the adapter still opens for users who
         # only need bare Cypher. `INSTALL` is the one that can reach the
         # network (see `_EXTENSION_INSTALL_TIMEOUT_SECONDS`), so it alone
-        # runs bounded; `LOAD` only touches the local cache once installed.
+        # runs bounded, and only once per extension per process
+        # (`_extension_install_ok`, same idea as `_confine_smoke_cache`
+        # above): a genuinely unavailable extension (missing platform
+        # build, registry outage) fails the same way on every adapter, so
+        # without the cache every single instantiation re-pays the same
+        # network round-trip — across a test suite that opens hundreds of
+        # adapters, that is what turned a few seconds of real unavailability
+        # into a CI job stuck for 30+ minutes. `LOAD` still runs every time
+        # (cheap, local, and connection-scoped once installed).
         for ext in ("vector", "fts", "algo"):
+            installed = _extension_install_ok.get(ext)
+            if installed is None:
+                try:
+                    self._install_extension(ext)
+                    installed = True
+                except Exception as e:  # noqa: BLE001
+                    installed = False
+                    warnings.warn(
+                        f"Ladybug extension {ext!r} unavailable: {e}. "
+                        f"{ext} queries will fail until the extension is loaded."
+                    )
+                _extension_install_ok[ext] = installed
+            if not installed:
+                continue
             try:
-                self._install_extension(ext)
                 self._con.execute(f"LOAD {ext}")
             except Exception as e:  # noqa: BLE001
                 warnings.warn(
-                    f"Ladybug extension {ext!r} unavailable: {e}. "
+                    f"Ladybug extension {ext!r} failed to load: {e}. "
                     f"{ext} queries will fail until the extension is loaded."
                 )
 


### PR DESCRIPTION
## Summary

`LadybugAdapter.__init__` runs `INSTALL {ext}` for `vector`/`fts`/`algo` unconditionally on every open. `INSTALL` on an extension not already cached fetches it over the network, and Ladybug's C++ layer runs that fetch synchronously with no timeout of its own — a stalled connection (flaky runner, rate-limited CDN) blocks `__init__` forever.

Observed downstream: CI jobs (macOS, all Python versions) stuck for 20+ minutes at "Run the tests" with no error, while the equivalent Linux jobs on the same run completed (slower than baseline, but finished) — consistent with a network hiccup during extension install rather than anything in the code under test. `duckdb_adapter.py` already guards against exactly this class of issue for `fts`/`vss` (#43); `ladybug_adapter.py` never got the equivalent treatment.

## Fix

`INSTALL` now runs in a daemon thread through a throwaway `:memory:` connection, bounded by a new `_EXTENSION_INSTALL_TIMEOUT_SECONDS` (15s):

- On timeout, it's treated the same as any other install failure — the existing warning fires, the adapter still opens for bare Cypher.
- The throwaway connection means an abandoned call never touches the shared `self._con` concurrently.
- The thread is a daemon, so an abandoned call can't block interpreter exit either (a plain `ThreadPoolExecutor` would: its `atexit` hook joins all outstanding work before the process can exit, which reproduces the same hang one level up).
- `INSTALL` writes into the extensions cache DuckDB-family engines share on disk, so a subsequent `LOAD` on `self._con` still finds it once the throwaway install actually lands — this only bounds how long `__init__` waits.

## Test plan

- [x] `ladybug_adapter_test.py`: 178 passed.
- [x] Full suite: `uv run pytest --cov-config=pyproject.toml` — 2171 passed, 9 skipped, 0 failed.
- [x] Verified the timeout actually fires: monkeypatched `ladybug.Connection.execute` to hang forever on `INSTALL`, confirmed `LadybugAdapter(uri="ladybug://:memory:")` still returns after ~45s (3 extensions × 15s) with the expected "extension unavailable" warnings, instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)