### PR TITLE
fix(rlm): support positional args in sandboxed tool calls

### DIFF
--- a/synalinks/src/modules/agents/rlm_agent.py
+++ b/synalinks/src/modules/agents/rlm_agent.py
@@ -3,6 +3,7 @@
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
 import asyncio
+import inspect
 import json
 from typing import List
 from typing import Optional
@@ -363,9 +364,27 @@ def _build_llm_query_batched_tool(sub_language_model, max_llm_calls, counter, lo
 def _adapt_tool_for_sandbox(tool):
     """Route a sandbox tool call through the `Tool` Module (preserving
     observability/retry) and return a plain dict the sandbox can marshal back.
-    """
 
-    async def adapter(**kwargs):
+    `Tool` (like every `Module`) only accepts plain Python values as
+    *keyword* arguments — `Module.__call__` rejects a non-DataModel
+    positional value outright, and `Tool.call(self, training=False,
+    **kwargs)` forwards kwargs only. A sandboxed snippet calls tools like
+    ordinary Python functions though, positionally or by keyword (the
+    built-in recursive helpers' own instructions show `llm_query(prompt)`,
+    not `llm_query(prompt=...)`), so a positional call has to be translated
+    to its keyword form here, using the wrapped function's own parameter
+    names/order, before it ever reaches `tool(...)`.
+    """
+    param_names = list(inspect.signature(tool._func).parameters)
+
+    async def adapter(*args, **kwargs):
+        if args:
+            if len(args) > len(param_names):
+                raise TypeError(
+                    f"{tool.name}() takes {len(param_names)} positional "
+                    f"argument(s) but {len(args)} were given"
+                )
+            kwargs = {**dict(zip(param_names, args)), **kwargs}
         result = await tool(**kwargs)
         if result is None:
             return None

--- a/synalinks/src/modules/agents/rlm_agent_test.py
+++ b/synalinks/src/modules/agents/rlm_agent_test.py
@@ -195,6 +195,64 @@ class RecursiveLanguageModelAgentTest(testing.TestCase):
         )
 
     @patch("litellm.acompletion")
+    async def test_llm_query_round_trip_positional_call(self, mock_completion):
+        """`llm_query(prompt)` called positionally — the shape the built-in
+        instructions themselves show (`llm_query(prompt)`, no `prompt=`) —
+        must work exactly like the keyword form. Regression test: the
+        sandbox's tool-call RPC bridge (bootstrap stub -> Unix socket -> host
+        dispatcher -> `_adapt_tool_for_sandbox`) used to be keyword-only at
+        every hop, so this raised `TypeError: _stub() takes 0 positional
+        arguments but 1 was given` even though `Tool.__call__` itself already
+        supports `*args`."""
+        language_model = LanguageModel(model="ollama/mistral")
+
+        inputs = Input(data_model=Query)
+        outputs = await RecursiveLanguageModelAgent(
+            data_model=Answer,
+            language_model=language_model,
+            max_iterations=3,
+        )(inputs)
+        agent = Program(inputs=inputs, outputs=outputs)
+
+        turn1 = {"code": ("out = llm_query('summarize this')\nprint(out['result'])")}
+        turn2 = {"code": "submit(result={'answer': 'done'})"}
+
+        mock_completion.side_effect = [
+            _exec_tool_call(turn1["code"], "call_1"),
+            {"choices": [{"message": {"content": "the gist is X"}}]},
+            _exec_tool_call(turn2["code"], "call_2"),
+        ]
+
+        result = await agent(Query(query="long doc here"))
+        self.assertEqual(result.get("answer"), "done")
+        tool_messages = [m for m in result.get("messages") if m.get("role") == "tool"]
+        self.assertTrue(
+            any("the gist is X" in str(m.get("content")) for m in tool_messages),
+            f"expected sub-LM response in tool observation; got: {tool_messages}",
+        )
+
+    @patch("litellm.acompletion")
+    async def test_user_tool_accepts_positional_call(self, mock_completion):
+        """A plain user tool (not a recursive helper) called positionally
+        through the sandbox — same RPC bridge, same regression."""
+        language_model = LanguageModel(model="ollama/mistral")
+
+        inputs = Input(data_model=Query)
+        outputs = await RecursiveLanguageModelAgent(
+            data_model=Answer,
+            language_model=language_model,
+            tools=[Tool(square)],
+            max_iterations=2,
+        )(inputs)
+        agent = Program(inputs=inputs, outputs=outputs)
+
+        turn1 = {"code": "out = square(5)\nsubmit(result={'answer': str(out['result'])})"}
+        mock_completion.side_effect = [_exec_tool_call(turn1["code"], "call_1")]
+
+        result = await agent(Query(query="square 5"))
+        self.assertEqual(result.get("answer"), "25")
+
+    @patch("litellm.acompletion")
     async def test_llm_query_batched_runs_concurrently(self, mock_completion):
         """`llm_query_batched` returns one response per prompt."""
         language_model = LanguageModel(model="ollama/mistral")

--- a/synalinks/src/sandboxes/mirage_sandbox.py
+++ b/synalinks/src/sandboxes/mirage_sandbox.py
@@ -655,9 +655,11 @@ if _inputs:
 _sock = config.get("sock")
 if _sock and config.get("tools"):
     import asyncio, struct, threading
-    async def _rpc(_name, **kwargs):
+    async def _rpc(_name, *args, **kwargs):
         reader, writer = await asyncio.open_unix_connection(_sock)
-        payload = json.dumps({"name": _name, "kwargs": kwargs}).encode("utf-8")
+        payload = json.dumps(
+            {"name": _name, "args": args, "kwargs": kwargs}
+        ).encode("utf-8")
         writer.write(struct.pack(">I", len(payload)) + payload)
         await writer.drain()
         header = await reader.readexactly(4)
@@ -676,9 +678,9 @@ if _sock and config.get("tools"):
     _tool_loop = asyncio.new_event_loop()
     threading.Thread(target=_tool_loop.run_forever, daemon=True).start()
     def _make_stub(_name):
-        def _stub(**kwargs):
+        def _stub(*args, **kwargs):
             return asyncio.run_coroutine_threadsafe(
-                _rpc(_name, **kwargs), _tool_loop
+                _rpc(_name, *args, **kwargs), _tool_loop
             ).result()
         return _stub
     for _tool_name in config["tools"]:
@@ -2672,8 +2674,8 @@ class MirageSandbox(Sandbox):
         """Build the Unix-socket handler that dispatches in-sandbox tool calls.
 
         Each connection carries one length-prefixed JSON request
-        ``{"name", "kwargs"}``; the named host callable runs (awaited if a
-        coroutine) and its JSON-marshalable return is sent back as
+        ``{"name", "args", "kwargs"}``; the named host callable runs (awaited
+        if a coroutine) and its JSON-marshalable return is sent back as
         ``{"ok": true, "result": ...}`` (or ``{"ok": false, "error": ...}``).
         """
 
@@ -2683,13 +2685,14 @@ class MirageSandbox(Sandbox):
                 (length,) = struct.unpack(">I", header)
                 request = json.loads((await reader.readexactly(length)).decode("utf-8"))
                 name = request.get("name")
+                args = request.get("args") or []
                 kwargs = request.get("kwargs") or {}
                 func = functions.get(name)
                 if func is None:
                     resp = {"ok": False, "error": f"unknown tool: {name}"}
                 else:
                     try:
-                        result = func(**kwargs)
+                        result = func(*args, **kwargs)
                         if inspect.isawaitable(result):
                             result = await result
                         resp = {"ok": True, "result": _jsonable(result)}

--- a/synalinks/src/sandboxes/mirage_sandbox_test.py
+++ b/synalinks/src/sandboxes/mirage_sandbox_test.py
@@ -138,6 +138,23 @@ class MirageSandboxTest(_SandboxTestCase):
         self.assertEqual(result.result, 7)
         self.assertEqual(called["n"], 1)
 
+    async def test_external_function_accepts_positional_args(self):
+        # Regression: the sandbox's tool-call RPC bridge (bootstrap stub ->
+        # Unix socket -> host dispatcher) used to marshal only `kwargs`, so a
+        # positional call raised `TypeError: _stub() takes 0 positional
+        # arguments but 1 was given` even though a plain Python call and
+        # `Tool.__call__` both support positional args fine.
+        async def adder(x, y):
+            return {"sum": x + y}
+
+        sandbox = MirageSandbox(timeout=_TIMEOUT)
+        result = await sandbox.run(
+            "out = adder(3, 4)\nprint(out['sum'])\n",
+            external_functions={"adder": adder},
+        )
+        self.assertTrue(result.ok, msg=result.error)
+        self.assertIn("7", result.stdout)
+
     async def test_bound_functions_persist_across_runs(self):
         captured = {}
 


### PR DESCRIPTION
## Summary
- A snippet inside `run_python_code` calls tools like ordinary Python functions, and the RLM agent's own built-in instructions show the recursive helpers called positionally (`llm_query(prompt)`, `llm_query_batched(prompts)` — no `prompt=`/`prompts=`). But the sandbox's tool-call RPC bridge (bootstrap stub -> Unix socket -> host dispatcher) only ever marshaled keyword arguments, so any positional call raised `TypeError: _stub() takes 0 positional arguments but 1 was given`.
- Reproduced live against a real model (`anthropic/claude-sonnet-5` and separately `vllm`-served Qwen3.6-35B-A3B): the agent tried `llm_query_batched(prompts)`, hit the error, reasoned *"The llm_query_batched function seems to have an issue. Let me try llm_query instead"*, and fell back to a slow sequential loop — burning many extra turns instead of one concurrent batch.
- Threads positional args through the RPC bridge (`_stub`/`_rpc` in the sandbox bootstrap script, and the host-side `_make_rpc_handler` dispatcher).
- `Tool` is a `Module`, so `Module.__call__` rejects a non-DataModel positional argument outright, and `Tool.call()` only forwards kwargs. Rather than trying to make `Tool` itself accept positional args (which would touch the framework-wide `Module.__call__` invariant), `_adapt_tool_for_sandbox`'s adapter now maps positional args to their keyword names — via the wrapped function's own `inspect.signature` — before calling the tool.

## Test plan
- [x] New regression test at the sandbox layer: `mirage_sandbox_test.py::test_external_function_accepts_positional_args` — a bound tool called positionally through a real `MirageSandbox`.
- [x] New regression tests at the agent layer: `rlm_agent_test.py::test_llm_query_round_trip_positional_call` (the exact real-world failure — `llm_query('summarize this')`) and `rlm_agent_test.py::test_user_tool_accepts_positional_call` (a plain user `Tool` called positionally).
- [x] Full framework test suite: `uv run pytest --cov-config=pyproject.toml` — 2176 passed, 9 skipped (macOS-only), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)