### PR TITLE
fix: share one live namespace across MirageSandbox runs

### DIFF
--- a/synalinks/src/sandboxes/mirage_sandbox.py
+++ b/synalinks/src/sandboxes/mirage_sandbox.py
@@ -652,6 +652,38 @@ if _inputs:
         ns.update(dill.loads(base64.b64decode(_inputs)))
     except Exception as exc:
         print("inputs-warn: " + repr(exc), file=sys.stderr)
+# Re-home restored functions onto the live ``ns``. dill pickles a function
+# together with a *private copy* of the globals it referenced, so a restored
+# function's ``__globals__`` is a ghost of the namespace as of the run that
+# defined it — while this run's snippet execs into ``ns``. Without re-homing,
+# a function defined in an earlier run can never see a name defined in a
+# later one (``def f(): return helper()`` then ``def helper(): ...`` next run
+# leaves ``f`` raising NameError forever), and every dump/restore round-trip
+# nests another ghost copy into the state file. Rebuilding each function on
+# ``ns`` restores true REPL semantics: one shared global namespace.
+import types as _types
+def _rehome(value):
+    if isinstance(value, _types.FunctionType) and value.__globals__ is not ns:
+        fixed = _types.FunctionType(
+            value.__code__, ns, value.__name__, value.__defaults__, value.__closure__
+        )
+        fixed.__kwdefaults__ = value.__kwdefaults__
+        fixed.__qualname__ = value.__qualname__
+        fixed.__dict__.update(value.__dict__)
+        fixed.__module__ = value.__module__
+        return fixed
+    return value
+for _key in list(ns):
+    _value = ns[_key] = _rehome(ns[_key])
+    if isinstance(_value, type):
+        # Methods of sandbox-defined classes carry the same ghost globals.
+        for _attr, _member in list(vars(_value).items()):
+            _fixed = _rehome(_member)
+            if _fixed is not _member:
+                try:
+                    setattr(_value, _attr, _fixed)
+                except (AttributeError, TypeError):
+                    pass
 _sock = config.get("sock")
 if _sock and config.get("tools"):
     import asyncio, struct, threading

--- a/synalinks/src/sandboxes/mirage_sandbox_test.py
+++ b/synalinks/src/sandboxes/mirage_sandbox_test.py
@@ -83,6 +83,39 @@ class MirageSandboxTest(_SandboxTestCase):
         result = await sandbox.run("print(sq(4), math.floor(2.7), P.v)")
         self.assertIn("16 2 3", result.stdout)
 
+    async def test_function_sees_names_defined_in_later_runs(self):
+        """A restored function shares the live namespace, like a real REPL.
+
+        dill pickles a function with a private copy of its globals; without
+        re-homing restored functions onto the live ``ns``, ``f`` here keeps a
+        ghost namespace frozen at definition time and raises NameError even
+        though ``helper`` is defined (top-down design: call first, fill in
+        after)."""
+        sandbox = MirageSandbox(timeout=_TIMEOUT)
+        await sandbox.run("def f(x):\n    return helper(x) + 1")
+        await sandbox.run("def helper(x):\n    return x * 10")
+        result = await sandbox.run("print(f(4))")
+        self.assertIn("41", result.stdout)
+
+    async def test_method_sees_names_defined_in_later_runs(self):
+        sandbox = MirageSandbox(timeout=_TIMEOUT)
+        await sandbox.run("class G:\n    def area(self):\n        return helper(3)")
+        await sandbox.run("def helper(x):\n    return x * 10")
+        result = await sandbox.run("print(G().area())")
+        self.assertIn("30", result.stdout)
+
+    async def test_rehomed_function_keeps_closure_and_kwdefaults(self):
+        sandbox = MirageSandbox(timeout=_TIMEOUT)
+        await sandbox.run(
+            "def make_adder(n):\n"
+            "    def add(x, *, scale=2):\n"
+            "        return (x + n) * scale\n"
+            "    return add\n"
+            "add5 = make_adder(5)"
+        )
+        result = await sandbox.run("print(add5(1), add5(1, scale=1))")
+        self.assertIn("12 6", result.stdout)
+
     async def test_state_survives_error(self):
         sandbox = MirageSandbox(timeout=_TIMEOUT)
         await sandbox.run("keep = 11")


### PR DESCRIPTION
## Problem

`MirageSandbox` persists REPL state by dill-pickling the user namespace after each `run` and restoring it in the next run's fresh process. dill pickles a function together with a **private copy** of the globals it references, so a restored function's `__globals__` is a ghost of the namespace as of the run that defined it — while each new snippet execs into the live `ns`. Two consequences:

- A function defined in an earlier run can never see a name defined in a later one. `def f(x): return helper(x)` in run 1, `def helper(x): ...` in run 2 → calling `f` raises `NameError: helper` forever, even though calling `helper` directly works. This breaks top-down composition across turns (an RLM agent defining a function before its helpers hits it hard — found via a live agent trajectory doing exactly that).
- Every dump/restore round-trip nests another ghost copy of the namespace into the state file.

## Fix

After restoring the state file (and the per-call `inputs`), re-home every restored function — and the methods of sandbox-defined classes — onto the live `ns` by rebuilding it with `types.FunctionType(code, ns, ...)`, preserving defaults, kwdefaults, closure cells, `__qualname__`, `__dict__` and `__module__`. Fresh tool stubs are installed after this point, so stale restored stubs are overwritten as before.

This restores true REPL semantics: one shared global namespace, exactly as if all snippets had run in a single interpreter.

## Tests

- `test_function_sees_names_defined_in_later_runs` — fails on main with `NameError`, passes with the fix
- `test_method_sees_names_defined_in_later_runs` — same, for methods of sandbox-defined classes
- `test_rehomed_function_keeps_closure_and_kwdefaults` — regression guard: re-homing preserves closures and keyword-only defaults

Full sandbox suite: 119 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)