### PR TITLE
fix(language-model): don't retry a stop an identical request reproduces

### DIFF
--- a/synalinks/src/modules/agents/function_calling_agent_test.py
+++ b/synalinks/src/modules/agents/function_calling_agent_test.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import warnings
 import tempfile
 from unittest.mock import patch
 
@@ -1157,3 +1158,31 @@ class SkillsToolWiringTest(testing.TestCase):
         # ...but rebuild from the `skills` config on reload.
         reloaded = FunctionCallingAgent.from_config(config)
         self.assertIn("read_skill", reloaded.tools)
+
+
+class TruncatedGenerationTest(testing.TestCase):
+    @patch("litellm.acompletion")
+    async def test_length_cut_stops_without_burning_retries(self, mock_completion):
+        language_model = LanguageModel(model="ollama/mistral", retry=3)
+        inputs = Input(data_model=ChatMessages)
+        outputs = await FunctionCallingAgent(
+            language_model=language_model,
+            tools=[Tool(calculate)],
+            autonomous=True,
+            max_iterations=3,
+        )(inputs)
+        agent = Program(inputs=inputs, outputs=outputs, name="truncated_test")
+
+        mock_completion.side_effect = [
+            {"choices": [{"message": {"content": ""}, "finish_reason": "length"}]},
+            _lm_response(content="final"),
+        ]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            await agent(
+                ChatMessages(messages=[ChatMessage(role="user", content="hi")])
+            )
+
+        # One turn (not retried three times), then the final generator.
+        self.assertEqual(mock_completion.call_count, 2)

--- a/synalinks/src/modules/language_models/language_model.py
+++ b/synalinks/src/modules/language_models/language_model.py
@@ -10,6 +10,7 @@ import litellm
 import orjson
 from tenacity import before_sleep_log
 from tenacity import retry
+from tenacity import retry_if_not_exception_type
 from tenacity import stop_after_attempt
 
 from synalinks.src.api_export import synalinks_export
@@ -42,6 +43,42 @@ def _safe_get(obj, key, default=None):
     else:
         v = getattr(obj, key, None)
     return default if v is None else v
+
+
+# Stop reasons an identical retry cannot change, so they are raised straight
+# through instead of consuming the retry budget.
+DETERMINISTIC_FINISH_REASONS = frozenset({"length", "content_filter", "safety"})
+
+_EMPTY_RESPONSE_CAUSES = {
+    "length": (
+        "the completion token budget was exhausted before any content or "
+        "tool_calls were produced -- raise `max_tokens`, lower the reasoning "
+        "effort, or shorten the prompt"
+    ),
+    "content_filter": "the provider blocked the completion",
+    "safety": "the provider blocked the completion",
+    "stop": "the model stopped without emitting anything",
+    "tool_calls": "the model signalled tool calls but sent none",
+}
+
+
+def _empty_response_message(finish_reason):
+    cause = _EMPTY_RESPONSE_CAUSES.get(
+        finish_reason, "no content or tool_calls were returned"
+    )
+    return (
+        f"Empty response from the language model "
+        f"(finish_reason={finish_reason!r}): {cause}."
+    )
+
+
+class DeterministicStopError(ValueError):
+    """An empty completion a retry cannot fix. Subclasses `ValueError` so
+    existing handlers keep working."""
+
+    def __init__(self, message, finish_reason):
+        super().__init__(message)
+        self.finish_reason = finish_reason
 
 
 def _to_int(v):
@@ -605,6 +642,8 @@ class LanguageModel(Module):
         self.last_call_cached_tokens = 0
         self.last_call_cache_creation_tokens = 0
         self.last_call_reasoning_tokens = 0
+        # Why the last completion stopped, from the response choice.
+        self.last_call_finish_reason = None
         # Phase-scoped counters, populated based on `synalinks_op_scope` set
         # by the trainer: "inference" inside `predict_on_batch`, "reward"
         # inside `compute_reward`, "optimizer" inside `optimizer.optimize`.
@@ -692,6 +731,9 @@ class LanguageModel(Module):
                 "which to call. Split into two calls: typically the tool-call "
                 "generator uses `tools` and the final generator uses `schema`."
             )
+        # Cleared per call: a cache hit or a streamed call has no choice to
+        # read it from and must not report the previous call's reason.
+        self.last_call_finish_reason = None
         input_kwargs = copy.deepcopy(kwargs)
         # Merge instance-level defaults; per-call kwargs win.
         kwargs = {**self.default_kwargs, **kwargs}
@@ -973,6 +1015,7 @@ class LanguageModel(Module):
             # Honor a rate-limit `Retry-After` header (e.g. Azure OpenAI TPM
             # throttling); fall back to exponential backoff for other errors.
             wait=rate_limit_aware_wait(max_wait=self.retry_max_wait),
+            retry=retry_if_not_exception_type(DeterministicStopError),
             before_sleep=before_sleep_log(logger, logging.WARNING),
             reraise=True,
         )
@@ -1042,6 +1085,8 @@ class LanguageModel(Module):
                         "Empty response from the language model: no choices returned."
                     )
                 response_message = response["choices"][0]["message"]
+                finish_reason = _safe_get(response["choices"][0], "finish_reason")
+                self.last_call_finish_reason = finish_reason
                 wire_tool_calls = _safe_get(response_message, "tool_calls", None)
                 refusal = _safe_get(response_message, "refusal")
                 audio = _safe_get(response_message, "audio")
@@ -1061,10 +1106,12 @@ class LanguageModel(Module):
                             raise ValueError(
                                 "The language model refused to answer: " + refusal
                             )
-                        raise ValueError(
-                            "Empty response from the language model: no content "
-                            "or tool_calls returned."
-                        )
+                        if finish_reason in DETERMINISTIC_FINISH_REASONS:
+                            raise DeterministicStopError(
+                                _empty_response_message(finish_reason),
+                                finish_reason,
+                            )
+                        raise ValueError(_empty_response_message(finish_reason))
                     response_str = response_str.strip() if response_str else ""
                 reasoning_content = response_message.get("reasoning_content")
                 thinking_blocks = response_message.get("thinking_blocks")

--- a/synalinks/src/modules/language_models/language_model_test.py
+++ b/synalinks/src/modules/language_models/language_model_test.py
@@ -3,6 +3,7 @@
 import base64
 import copy
 import os
+import warnings
 from unittest.mock import patch
 
 from litellm.types.utils import Choices
@@ -254,7 +255,7 @@ class LanguageModelTest(testing.TestCase):
             "choices": [{"message": {"content": '{"answer":"4"}'}}]
         }
 
-        result = await language_model(messages, schema=Answer.get_schema())
+        result = await language_model(messages, schema=_FinishReasonAnswer.get_schema())
 
         self.assertEqual(result.get_json(), {"answer": "4"})
         response_format = mock_completion.call_args.kwargs["response_format"]
@@ -711,8 +712,8 @@ class LMFileCacheTest(testing.TestCase):
         }
         lm = LanguageModel(model="openai/gpt-4o", cache_dir=cache_dir)
 
-        first = await lm(_chat_messages(), schema=Answer.get_schema())
-        second = await lm(_chat_messages(), schema=Answer.get_schema())
+        first = await lm(_chat_messages(), schema=_FinishReasonAnswer.get_schema())
+        second = await lm(_chat_messages(), schema=_FinishReasonAnswer.get_schema())
 
         self.assertEqual(mock_completion.call_count, 1)
         self.assertEqual(first.get_json(), {"answer": "Toulouse"})
@@ -850,3 +851,88 @@ class ToolWireFormatTest(testing.TestCase):
         self.assertEqual(parameters["type"], "object")
         self.assertEqual(set(parameters["properties"]), {"query", "limit"})
         self.assertEqual(sorted(parameters["required"]), ["limit", "query"])
+
+
+class _FinishReasonAnswer(DataModel):
+    answer: str
+
+
+class FinishReasonTest(testing.TestCase):
+    """`finish_reason` is a choice field, so it is reported on the model
+    (`last_call_finish_reason`) rather than on the returned message."""
+
+    @staticmethod
+    def _response(content="", finish_reason="stop"):
+        return {
+            "choices": [
+                {"message": {"content": content}, "finish_reason": finish_reason}
+            ]
+        }
+
+    @patch("litellm.acompletion")
+    async def test_finish_reason_is_reported_on_the_model(self, mock_completion):
+        mock_completion.return_value = self._response(content="hi", finish_reason="stop")
+        lm = LanguageModel(model="ollama/mistral")
+        response = await lm(_chat_messages())
+        self.assertEqual(response.get("content"), "hi")
+        self.assertEqual(lm.last_call_finish_reason, "stop")
+        # The message stays exactly a chat-completion message.
+        self.assertNotIn("finish_reason", response.get_json())
+
+    @patch("litellm.acompletion")
+    async def test_finish_reason_is_cleared_between_calls(self, mock_completion):
+        lm = LanguageModel(model="ollama/mistral")
+        mock_completion.return_value = self._response(content="hi", finish_reason="length")
+        await lm(_chat_messages())
+        self.assertEqual(lm.last_call_finish_reason, "length")
+        mock_completion.return_value = {"choices": [{"message": {"content": "hi"}}]}
+        await lm(_chat_messages())
+        self.assertIsNone(lm.last_call_finish_reason)
+
+    @patch("litellm.acompletion")
+    async def test_length_cut_is_reported_once_not_retried(self, mock_completion):
+        # An identical retry reproduces a spent budget, so it costs
+        # `retry` x `timeout` and buys nothing.
+        mock_completion.return_value = self._response(finish_reason="length")
+        lm = LanguageModel(model="ollama/mistral", retry=3)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = await lm(_chat_messages())
+        self.assertEqual(mock_completion.call_count, 1)
+        self.assertIsNone(result)
+        self.assertEqual(lm.last_call_finish_reason, "length")
+
+    @patch("litellm.acompletion")
+    async def test_blocked_completion_is_reported_once_not_retried(
+        self, mock_completion
+    ):
+        mock_completion.return_value = self._response(finish_reason="content_filter")
+        lm = LanguageModel(model="ollama/mistral", retry=3)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            await lm(_chat_messages())
+        self.assertEqual(mock_completion.call_count, 1)
+        self.assertEqual(lm.last_call_finish_reason, "content_filter")
+
+    @patch("litellm.acompletion")
+    async def test_transient_empty_response_still_retries(self, mock_completion):
+        # The case a retry does fix keeps its retries.
+        mock_completion.return_value = self._response(finish_reason="stop")
+        lm = LanguageModel(model="ollama/mistral", retry=3)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = await lm(_chat_messages())
+        self.assertEqual(mock_completion.call_count, 3)
+        self.assertIsNone(result)
+
+    @patch("litellm.acompletion")
+    async def test_empty_response_error_names_the_cause(self, mock_completion):
+        mock_completion.return_value = self._response(finish_reason="length")
+        lm = LanguageModel(model="ollama/mistral", retry=3)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            await lm(_chat_messages(), schema=_FinishReasonAnswer.get_schema())
+        messages = " ".join(str(w.message) for w in caught)
+        self.assertIn("finish_reason='length'", messages)
+        self.assertIn("completion token budget was exhausted", messages)
+        self.assertIn("max_tokens", messages)


### PR DESCRIPTION
## Problem

`LanguageModel` treats every empty completion the same way: raise, then retry the identical request until `retry` is exhausted.

But an empty completion has several causes, and they need opposite responses. A transient provider glitch is fixed by a retry. `finish_reason="length"` — the completion budget spent before anything was emitted, which reasoning models hit routinely when the parser withholds every token until a closing tag that never arrives — is not. Neither is `content_filter`. Re-sending the same request reproduces them, at a cost of `retry × timeout` per turn.

Measured on a live agent task: 8 such events, each retried 3× against a 400s call timeout, consuming most of a 2400s budget before the run gave up anyway.

The error message made this invisible too — every case read `"Empty response from the language model: no content or tool_calls returned."`, the one symptom they all share, naming neither the cause nor which knob to reach for.

## Change

- `DETERMINISTIC_FINISH_REASONS = {"length", "content_filter", "safety"}` raise `DeterministicStopError`, excluded from the retry predicate via `retry_if_not_exception_type`. One request instead of `retry × timeout`. It subclasses `ValueError`, so existing handlers keep working.
- The empty-response error names the stop reason and the remedy:
  ```
  Empty response from the language model (finish_reason='length'): the completion
  token budget was exhausted before any content or tool_calls were produced --
  raise `max_tokens`, lower the reasoning effort, or shorten the prompt.
  ```
- `last_call_finish_reason` records the reason from the response choice, alongside the existing `last_call_*` fields. Cleared per call, so a cache hit or a streamed call — neither of which has a choice to read — reports `None` rather than the previous call's reason.

`finish_reason` is deliberately **not** put on `ChatMessage`: it is a field of the *choice*, not the message, in both the OpenAI spec and litellm's own types, and `ChatMessage` keeps exact key parity with the Chat Completions message.

No agent change is needed. The call returns `None` exactly as before, and `_run_loop`'s existing empty-generation break ends the run — now after one request instead of three.

## Tests

- deterministic stops cost one provider call with `retry=3`; transient empties still consume all three
- the reason lands on `last_call_finish_reason` and is cleared between calls
- the returned message stays exactly a chat-completion message (no `finish_reason` key)
- the error text names the reason and the knob
- end-to-end through an unmodified `FunctionCallingAgent`: a length cut costs 2 calls (one turn + final generator), not 4

Full suite: 2159 passed, 36 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)