### PR TITLE
fix(mirage-sandbox): don't re-home imported functions onto the sandbox namespace

### DIFF
--- a/synalinks/src/sandboxes/mirage_sandbox.py
+++ b/synalinks/src/sandboxes/mirage_sandbox.py
@@ -661,9 +661,22 @@ if _inputs:
 # leaves ``f`` raising NameError forever), and every dump/restore round-trip
 # nests another ghost copy into the state file. Rebuilding each function on
 # ``ns`` restores true REPL semantics: one shared global namespace.
+#
+# Only functions *defined in the sandbox* may be re-homed. An imported
+# function closes over its own module's globals, and rebuilding it on ``ns``
+# strips the module internals it reaches at call time: re-homing
+# ``collections.Counter``'s methods makes ``Counter('aa')`` raise
+# ``NameError: name '_collections_abc' is not defined``, and re-homing
+# ``os.path.join`` loses ``sep``. Sandbox-defined functions are the ones whose
+# (ghost) globals are a copy of ``ns``, which carries ``__name__ ==
+# "__main__"``; an imported one carries its own module name.
 import types as _types
 def _rehome(value):
-    if isinstance(value, _types.FunctionType) and value.__globals__ is not ns:
+    if (
+        isinstance(value, _types.FunctionType)
+        and value.__globals__ is not ns
+        and value.__globals__.get("__name__") == "__main__"
+    ):
         fixed = _types.FunctionType(
             value.__code__, ns, value.__name__, value.__defaults__, value.__closure__
         )

--- a/synalinks/src/sandboxes/mirage_sandbox_test.py
+++ b/synalinks/src/sandboxes/mirage_sandbox_test.py
@@ -116,6 +116,35 @@ class MirageSandboxTest(_SandboxTestCase):
         result = await sandbox.run("print(add5(1), add5(1, scale=1))")
         self.assertIn("12 6", result.stdout)
 
+    async def test_imported_function_keeps_its_own_module_globals(self):
+        """Re-homing must not touch functions imported from a module.
+
+        An imported function closes over its *module's* globals and reaches
+        names in them at call time. Rebuilding it on the sandbox namespace
+        strips those: ``os.path.join`` re-homed this way loses ``sep``."""
+        sandbox = MirageSandbox(timeout=_TIMEOUT)
+        await sandbox.run("from os.path import join")
+        result = await sandbox.run("print(join('a', 'b'))")
+        self.assertIn("a/b", result.stdout)
+        self.assertFalse(result.error)
+
+    async def test_imported_class_methods_keep_their_module_globals(self):
+        """Same for the methods of an imported class.
+
+        ``Counter.update`` reads ``_collections_abc`` and ``_count_elements``
+        from ``collections``' own globals, so re-homing it onto the sandbox
+        namespace made ``Counter('aa')`` raise NameError on every run after
+        the one that imported it. Worse, the class is re-homed *in place*, so
+        a later plain ``import collections`` inherited the damage."""
+        sandbox = MirageSandbox(timeout=_TIMEOUT)
+        await sandbox.run("from collections import Counter")
+        result = await sandbox.run("print(Counter('aab')['a'])")
+        self.assertIn("2", result.stdout)
+        self.assertFalse(result.error)
+        fresh = await sandbox.run("import collections\nprint(collections.Counter('aab')['a'])")
+        self.assertIn("2", fresh.stdout)
+        self.assertFalse(fresh.error)
+
     async def test_state_survives_error(self):
         sandbox = MirageSandbox(timeout=_TIMEOUT)
         await sandbox.run("keep = 11")


### PR DESCRIPTION
## The bug

`MirageSandbox` persists its namespace between `run` calls with dill, then re-homes restored functions onto the live `ns` so they share one global namespace (#92). The predicate matched **any** function whose `__globals__` was not `ns` — including functions imported from a module:

```python
sandbox.run("from collections import Counter")   # run 1
sandbox.run("Counter('aa')")                     # run 2
# NameError: name '_collections_abc' is not defined
```

An imported function closes over its own module's globals and reaches names in them at call time. `Counter.update` reads `_collections_abc` and `_count_elements` from `collections`' globals; `os.path.join` reads `sep` from `posixpath`'s. Rebuilding them on `ns` strips exactly those.

Because classes are re-homed in place (`setattr` on the class object), the damage outlived the name that triggered it: after any run imported `Counter`, a later plain `import collections` inherited the broken class.

Found in a long agent run, where it accounted for 264 sandbox failures across four tasks — `_collections_abc` (122), `sep` (62), `_itemgetter` (48), `_count_elements` (32). It only bites from the *second* run onward, which is what makes it confusing in the wild: the import turn works, and the code that uses the import fails.

## The fix

Re-home only functions **defined in the sandbox**. Their ghost globals are a copy of `ns`, which carries `__name__ == "__main__"`; an imported function carries its own module name. One extra clause on the existing predicate.

## Tests

Two colocated tests, both failing on `main` and passing here:

- `test_imported_function_keeps_its_own_module_globals` — `os.path.join` still works a run after it was imported.
- `test_imported_class_methods_keep_their_module_globals` — `Counter` works a run after import, and a subsequent plain `import collections` is undamaged.

The cross-run cases #92 added (`test_function_sees_names_defined_in_later_runs`, `test_method_sees_names_defined_in_later_runs`, `test_rehomed_function_keeps_closure_and_kwdefaults`) still pass, so this narrows the predicate without giving back what #92 bought.

Full sandbox suite: 121 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)