### PR TITLE
Score scales for SelfCritique/LMAsJudge, symbolic auto-build, bump 0.9.014

### DIFF
--- a/synalinks/__init__.py
+++ b/synalinks/__init__.py
@@ -51,6 +51,7 @@ from synalinks.api import EntityRegexSearch
 from synalinks.api import EntitySimilaritySearch
 from synalinks.api import ExactMatch
 from synalinks.api import ExecutionResult
+from synalinks.api import FineScore
 from synalinks.api import FullTextSearch
 from synalinks.api import Function
 from synalinks.api import FunctionCallingAgent
@@ -111,6 +112,9 @@ from synalinks.api import Program
 from synalinks.api import ProgramAsJudge
 from synalinks.api import ProgramOperationalMetric
 from synalinks.api import PythonSynthesis
+from synalinks.api import Rating
+from synalinks.api import Rating10
+from synalinks.api import Rating20
 from synalinks.api import RecursiveLanguageModelAgent
 from synalinks.api import RegexSearch
 from synalinks.api import Relation

--- a/synalinks/api/__init__.py
+++ b/synalinks/api/__init__.py
@@ -169,6 +169,10 @@ from synalinks.src.backend.pydantic.knowledge import is_relation as is_relation
 from synalinks.src.backend.pydantic.knowledge import is_relations as is_relations
 from synalinks.src.backend.pydantic.media import Audio as Audio
 from synalinks.src.backend.pydantic.media import Image as Image
+from synalinks.src.backend.pydantic.metrics import FineScore as FineScore
+from synalinks.src.backend.pydantic.metrics import Rating as Rating
+from synalinks.src.backend.pydantic.metrics import Rating10 as Rating10
+from synalinks.src.backend.pydantic.metrics import Rating20 as Rating20
 from synalinks.src.backend.pydantic.metrics import Score as Score
 from synalinks.src.datasets.csv_dataset import CSVDataset as CSVDataset
 from synalinks.src.datasets.dataset import Dataset as Dataset

--- a/synalinks/api/backend/__init__.py
+++ b/synalinks/api/backend/__init__.py
@@ -93,5 +93,11 @@ from synalinks.src.backend.pydantic.knowledge import is_relation as is_relation
 from synalinks.src.backend.pydantic.knowledge import is_relations as is_relations
 from synalinks.src.backend.pydantic.media import Audio as Audio
 from synalinks.src.backend.pydantic.media import Image as Image
+from synalinks.src.backend.pydantic.metrics import FineScore as FineScore
+from synalinks.src.backend.pydantic.metrics import Rating as Rating
+from synalinks.src.backend.pydantic.metrics import Rating10 as Rating10
+from synalinks.src.backend.pydantic.metrics import Rating20 as Rating20
 from synalinks.src.backend.pydantic.metrics import Score as Score
+from synalinks.src.backend.pydantic.metrics import get_score_type as get_score_type
+from synalinks.src.backend.pydantic.metrics import normalize_score as normalize_score
 from synalinks.src.utils.naming import get_uid as get_uid

--- a/synalinks/src/backend/__init__.py
+++ b/synalinks/src/backend/__init__.py
@@ -89,7 +89,13 @@ if backend() == "pydantic":
     from synalinks.src.backend.pydantic.media import Audio
     from synalinks.src.backend.pydantic.media import Image
     from synalinks.src.backend.pydantic.media import resolve_content_media
+    from synalinks.src.backend.pydantic.metrics import FineScore
+    from synalinks.src.backend.pydantic.metrics import Rating
+    from synalinks.src.backend.pydantic.metrics import Rating10
+    from synalinks.src.backend.pydantic.metrics import Rating20
     from synalinks.src.backend.pydantic.metrics import Score
+    from synalinks.src.backend.pydantic.metrics import get_score_type
+    from synalinks.src.backend.pydantic.metrics import normalize_score
     from synalinks.src.backend.pydantic.module import PydanticModule
 else:
     raise ValueError(f"Unable to import backend : {backend()}")

--- a/synalinks/src/backend/pydantic/metrics.py
+++ b/synalinks/src/backend/pydantic/metrics.py
@@ -5,6 +5,8 @@
 from enum import Enum
 
 from synalinks.src.api_export import synalinks_export
+from synalinks.src.saving.object_registration import get_registered_name
+from synalinks.src.saving.object_registration import get_registered_object
 
 
 @synalinks_export(
@@ -72,3 +74,364 @@ class Score(float, Enum):
     HIGH_AVERAGE = 0.8
     GOOD = 0.9
     VERY_GOOD = 1.0
+
+
+@synalinks_export(
+    [
+        "synalinks.backend.FineScore",
+        "synalinks.FineScore",
+    ]
+)
+class FineScore(float, Enum):
+    """A discretized confidence score on a 21-level scale from 0.0 to 1.0.
+
+    `FineScore` is the finer-grained sibling of `Score`: it steps by 0.05
+    instead of 0.1, giving the language model twice the resolution when it
+    picks a confidence level. Every `Score` value is also a `FineScore`
+    value (with the same name), with one extra level slotted between each
+    pair. Like `Score`, it is both a `float` and an `Enum`, so the JSON
+    schema constrains the model to one of the fixed values while Python
+    code can use the value in arithmetic directly.
+
+    Reach for `FineScore` when the 11 levels of `Score` are too coarse
+    (e.g. ranking many candidates that would otherwise tie), and stay with
+    `Score` when you want the model to commit to broader buckets.
+
+    The labels:
+
+    | Name                   | Value |
+    | ---------------------- | ----- |
+    | `VERY_BAD`             | 0.00  |
+    | `BAD`                  | 0.05  |
+    | `POOR`                 | 0.10  |
+    | `VERY_LOW`             | 0.15  |
+    | `BELOW_AVERAGE`        | 0.20  |
+    | `LOW`                  | 0.25  |
+    | `LOW_AVERAGE`          | 0.30  |
+    | `SLIGHTLY_LOW`         | 0.35  |
+    | `MEDIUM_LOW`           | 0.40  |
+    | `SLIGHTLY_BELOW_MEDIUM`| 0.45  |
+    | `MEDIUM`               | 0.50  |
+    | `SLIGHTLY_ABOVE_MEDIUM`| 0.55  |
+    | `MEDIUM_HIGH`          | 0.60  |
+    | `SLIGHTLY_HIGH`        | 0.65  |
+    | `ABOVE_AVERAGE`        | 0.70  |
+    | `HIGH`                 | 0.75  |
+    | `HIGH_AVERAGE`         | 0.80  |
+    | `VERY_HIGH`            | 0.85  |
+    | `GOOD`                 | 0.90  |
+    | `EXCELLENT`            | 0.95  |
+    | `VERY_GOOD`            | 1.00  |
+
+    Example:
+
+    ```python
+    import synalinks
+
+    class Relevance(synalinks.DataModel):
+        relevance: synalinks.FineScore = synalinks.Field(
+            description="How relevant the document is to the query",
+        )
+
+    # FineScore values are real floats, usable in arithmetic.
+    assert synalinks.FineScore.HIGH == 0.75
+    assert synalinks.FineScore.GOOD == synalinks.Score.GOOD
+    ```
+    """
+
+    VERY_BAD = 0.0
+    BAD = 0.05
+    POOR = 0.1
+    VERY_LOW = 0.15
+    BELOW_AVERAGE = 0.2
+    LOW = 0.25
+    LOW_AVERAGE = 0.3
+    SLIGHTLY_LOW = 0.35
+    MEDIUM_LOW = 0.4
+    SLIGHTLY_BELOW_MEDIUM = 0.45
+    MEDIUM = 0.5
+    SLIGHTLY_ABOVE_MEDIUM = 0.55
+    MEDIUM_HIGH = 0.6
+    SLIGHTLY_HIGH = 0.65
+    ABOVE_AVERAGE = 0.7
+    HIGH = 0.75
+    HIGH_AVERAGE = 0.8
+    VERY_HIGH = 0.85
+    GOOD = 0.9
+    EXCELLENT = 0.95
+    VERY_GOOD = 1.0
+
+
+@synalinks_export(
+    [
+        "synalinks.backend.Rating",
+        "synalinks.Rating",
+    ]
+)
+class Rating(int, Enum):
+    """A discretized rating on a 5-level integer scale from 1 to 5.
+
+    `Rating` is the integer, Likert-style counterpart of `Score`: instead
+    of a float between 0.0 and 1.0, the language model picks one of five
+    whole numbers, 1 (worst) to 5 (best). Because `Rating` is both an `int`
+    and an `Enum`, the JSON schema constrains the model to exactly those
+    five values while Python code can use the value in arithmetic
+    directly (e.g. averaging several ratings, or dividing by 5 to get a
+    score between 0.2 and 1.0).
+
+    Reach for `Rating` when you want the familiar "rate this from 1 to 5"
+    framing (star ratings, Likert surveys, rubric grades), and for `Score`
+    or `FineScore` when you want a normalized float.
+
+    The labels are the spelled-out numbers `ONE` (1) through `FIVE` (5).
+
+    Example:
+
+    ```python
+    import synalinks
+
+    class Review(synalinks.DataModel):
+        rating: synalinks.Rating = synalinks.Field(
+            description="Overall quality of the answer, from 1 (worst) to 5 (best)",
+        )
+
+    # Rating values are real ints, usable in arithmetic.
+    assert synalinks.Rating.FOUR == 4
+    normalized = synalinks.Rating.FOUR / 5  # 0.8
+    ```
+    """
+
+    ONE = 1
+    TWO = 2
+    THREE = 3
+    FOUR = 4
+    FIVE = 5
+
+
+@synalinks_export(
+    [
+        "synalinks.backend.Rating10",
+        "synalinks.Rating10",
+    ]
+)
+class Rating10(int, Enum):
+    """A discretized rating on a 10-level integer scale from 1 to 10.
+
+    `Rating10` is the 10-point variant of `Rating`: the language model
+    picks one whole number from 1 (worst) to 10 (best). Like `Rating`, it
+    is both an `int` and an `Enum`, so the JSON schema constrains the model
+    to exactly those ten values while Python code can use the value in
+    arithmetic directly (e.g. divide by 10 to get a score between 0.1 and
+    1.0).
+
+    Reach for `Rating10` when the 5 levels of `Rating` are too coarse but
+    you still want the "rate this out of 10" framing; use `Rating20` for
+    an even finer integer scale, and `Score` / `FineScore` when you want a
+    normalized float instead.
+
+    The labels are the spelled-out numbers `ONE` (1) through `TEN` (10).
+
+    Example:
+
+    ```python
+    import synalinks
+
+    class Review(synalinks.DataModel):
+        rating: synalinks.Rating10 = synalinks.Field(
+            description="Overall quality of the answer, from 1 (worst) to 10 (best)",
+        )
+
+    # Rating10 values are real ints, usable in arithmetic.
+    assert synalinks.Rating10.SEVEN == 7
+    normalized = synalinks.Rating10.SEVEN / 10  # 0.7
+    ```
+    """
+
+    ONE = 1
+    TWO = 2
+    THREE = 3
+    FOUR = 4
+    FIVE = 5
+    SIX = 6
+    SEVEN = 7
+    EIGHT = 8
+    NINE = 9
+    TEN = 10
+
+
+@synalinks_export(
+    [
+        "synalinks.backend.Rating20",
+        "synalinks.Rating20",
+    ]
+)
+class Rating20(int, Enum):
+    """A discretized rating on a 20-level integer scale from 1 to 20.
+
+    `Rating20` is the 20-point variant of `Rating`: the language model
+    picks one whole number from 1 (worst) to 20 (best). Like `Rating`, it
+    is both an `int` and an `Enum`, so the JSON schema constrains the model
+    to exactly those twenty values while Python code can use the value in
+    arithmetic directly (e.g. divide by 20 to get a score between 0.05 and
+    1.0).
+
+    Reach for `Rating20` when you need fine integer resolution (e.g. a
+    "grade out of 20" rubric, or ranking many candidates that would tie on
+    a coarser scale); use `Rating` or `Rating10` for broader buckets, and
+    `Score` / `FineScore` when you want a normalized float instead.
+
+    The labels are the spelled-out numbers `ONE` (1) through `TWENTY` (20).
+
+    Example:
+
+    ```python
+    import synalinks
+
+    class Grade(synalinks.DataModel):
+        grade: synalinks.Rating20 = synalinks.Field(
+            description="Grade of the essay, from 1 (worst) to 20 (best)",
+        )
+
+    # Rating20 values are real ints, usable in arithmetic.
+    assert synalinks.Rating20.FIFTEEN == 15
+    normalized = synalinks.Rating20.FIFTEEN / 20  # 0.75
+    ```
+    """
+
+    ONE = 1
+    TWO = 2
+    THREE = 3
+    FOUR = 4
+    FIVE = 5
+    SIX = 6
+    SEVEN = 7
+    EIGHT = 8
+    NINE = 9
+    TEN = 10
+    ELEVEN = 11
+    TWELVE = 12
+    THIRTEEN = 13
+    FOURTEEN = 14
+    FIFTEEN = 15
+    SIXTEEN = 16
+    SEVENTEEN = 17
+    EIGHTEEN = 18
+    NINETEEN = 19
+    TWENTY = 20
+
+
+# Built-in discretized scales, keyed by their registered (class) name, so
+# modules can accept a `score_type` as either the class or its string name
+# and round-trip it through `get_config()` / `from_config()`.
+_BUILTIN_SCORE_TYPES = {
+    "Score": Score,
+    "FineScore": FineScore,
+    "Rating": Rating,
+    "Rating10": Rating10,
+    "Rating20": Rating20,
+}
+
+
+def _is_score_type(obj):
+    return (
+        isinstance(obj, type)
+        and issubclass(obj, Enum)
+        and issubclass(obj, (int, float))
+        and not issubclass(obj, bool)
+        and len(obj) > 0
+    )
+
+
+@synalinks_export("synalinks.backend.get_score_type")
+def get_score_type(identifier):
+    """Resolve a discretized score scale from a class or a string name.
+
+    A "score type" is any `Enum` whose members are also `int` or `float`
+    (`Score`, `FineScore`, `Rating`, `Rating10`, `Rating20`, or your own).
+    Modules such as `SelfCritique` and `LMAsJudge` take a `score_type`
+    argument and use this helper so that both the class itself and its
+    name (as stored in a serialized config) are accepted.
+
+    Args:
+        identifier (type | str | None): The score type class, its name
+            (`"Score"`, `"FineScore"`, `"Rating"`, `"Rating10"`, `"Rating20"`,
+            or the registered name of a custom one), or `None` for the
+            default `Score`.
+
+    Returns:
+        (type): The resolved score type class.
+    """
+    if identifier is None:
+        return Score
+    if isinstance(identifier, str):
+        score_type = _BUILTIN_SCORE_TYPES.get(identifier)
+        if score_type is None:
+            score_type = get_registered_object(identifier)
+        if score_type is None or not _is_score_type(score_type):
+            raise ValueError(
+                f"Unknown score type '{identifier}'. Expected one of "
+                f"{list(_BUILTIN_SCORE_TYPES)} or the registered name of an "
+                "`Enum` subclass whose members are `int` or `float`."
+            )
+        return score_type
+    if _is_score_type(identifier):
+        return identifier
+    raise ValueError(
+        "Could not interpret score type identifier: "
+        f"{identifier!r}. Expected a class inheriting from `Enum` and `int` "
+        "or `float` (e.g. `synalinks.Score`, `synalinks.Rating`) or its name."
+    )
+
+
+def serialize_score_type(score_type):
+    """Return the string name under which a score type is serialized."""
+    return get_registered_name(get_score_type(score_type))
+
+
+def score_type_bounds(score_type):
+    """Return `(minimum, maximum)` member values of a score type."""
+    values = [member.value for member in get_score_type(score_type)]
+    return min(values), max(values)
+
+
+def score_type_json_type(score_type):
+    """Return the JSON schema `type` (`"integer"` or `"number"`) of a score type."""
+    score_type = get_score_type(score_type)
+    return "integer" if issubclass(score_type, int) else "number"
+
+
+def score_type_description(score_type):
+    """Return a short, LM-facing description of the scale of a score type."""
+    score_type = get_score_type(score_type)
+    lo, hi = score_type_bounds(score_type)
+    if issubclass(score_type, int):
+        return f"an integer between {lo} and {hi}, {lo} being very bad and {hi} very good"
+    return f"a float between {lo} and {hi}, {lo} being very bad and {hi} very good"
+
+
+@synalinks_export("synalinks.backend.normalize_score")
+def normalize_score(value, score_type):
+    """Normalize a raw score to a float between 0.0 and 1.0.
+
+    The lowest member of `score_type` maps to `0.0` and the highest to
+    `1.0`, linearly in between; e.g. `Rating.THREE` (3 on a 1..5 scale)
+    maps to `0.5`, `Rating10.SEVEN` to `0.667`, and any `Score` /
+    `FineScore` value is returned unchanged since it already spans 0..1.
+    The result is clamped to `[0.0, 1.0]` so a value slightly outside the
+    scale (e.g. from a lenient provider) cannot produce an invalid reward.
+
+    Args:
+        value (int | float | Enum): The raw score, as emitted by the
+            language model (a plain number or a member of `score_type`).
+        score_type (type | str): The scale the value was picked from
+            (see `get_score_type`).
+
+    Returns:
+        (float): The normalized score between 0.0 and 1.0.
+    """
+    lo, hi = score_type_bounds(score_type)
+    value = float(value)
+    if hi == lo:
+        return 1.0
+    normalized = (value - lo) / (hi - lo)
+    return min(1.0, max(0.0, normalized))

--- a/synalinks/src/backend/pydantic/metrics_test.py
+++ b/synalinks/src/backend/pydantic/metrics_test.py
@@ -1,0 +1,62 @@
+# License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
+
+from synalinks.src import testing
+from synalinks.src.backend import DataModel
+from synalinks.src.backend import Field
+from synalinks.src.backend.pydantic.metrics import FineScore
+from synalinks.src.backend.pydantic.metrics import Rating
+from synalinks.src.backend.pydantic.metrics import Rating10
+from synalinks.src.backend.pydantic.metrics import Rating20
+from synalinks.src.backend.pydantic.metrics import Score
+
+
+def _enum_schema(enum_cls):
+    class Holder(DataModel):
+        value: enum_cls = Field(description="value")
+
+    return Holder.get_schema()["$defs"][enum_cls.__name__]
+
+
+class MetricsTest(testing.TestCase):
+    def test_score_levels(self):
+        values = [m.value for m in Score]
+        self.assertEqual(len(values), 11)
+        self.assertEqual(values, [round(i / 10, 2) for i in range(11)])
+        self.assertEqual(_enum_schema(Score)["type"], "number")
+
+    def test_fine_score_levels(self):
+        values = [m.value for m in FineScore]
+        self.assertEqual(len(values), 21)
+        self.assertEqual(values, [round(i / 20, 2) for i in range(21)])
+        schema = _enum_schema(FineScore)
+        self.assertEqual(schema["type"], "number")
+        self.assertEqual(schema["enum"], values)
+
+    def test_fine_score_is_superset_of_score(self):
+        for member in Score:
+            self.assertEqual(FineScore[member.name].value, member.value)
+
+    def test_score_arithmetic(self):
+        self.assertAlmostEqual(Score.GOOD + 0.05, 0.95)
+        self.assertAlmostEqual(FineScore.HIGH * 2, 1.5)
+
+    def test_rating_levels(self):
+        for enum_cls, n in ((Rating, 5), (Rating10, 10), (Rating20, 20)):
+            values = [m.value for m in enum_cls]
+            self.assertEqual(values, list(range(1, n + 1)), enum_cls.__name__)
+            schema = _enum_schema(enum_cls)
+            self.assertEqual(schema["type"], "integer", enum_cls.__name__)
+            self.assertEqual(schema["enum"], values, enum_cls.__name__)
+
+    def test_rating_arithmetic(self):
+        self.assertEqual(Rating.FOUR / 5, 0.8)
+        self.assertEqual(Rating10.SEVEN + 3, 10)
+        self.assertEqual(Rating20.TWENTY // 4, 5)
+
+    def test_rating_validation(self):
+        class Holder(DataModel):
+            value: Rating = Field(description="value")
+
+        self.assertEqual(Holder(value=3).value, Rating.THREE)
+        with self.assertRaises(Exception):
+            Holder(value=6)

--- a/synalinks/src/modules/agents/deep_agent.py
+++ b/synalinks/src/modules/agents/deep_agent.py
@@ -520,10 +520,8 @@ class DeepAgent(FunctionCallingAgent):
                 name=f"{self.name}_sub{index}",
             )
             # Run the subagent through a Program, the canonical execution
-            # path. A direct eager call would re-run the agent's
-            # `compute_output_spec` on concrete inputs (extra throwaway LM
-            # calls); building once with a symbolic Input keeps that step
-            # LM-free, so the subagent costs the same as a normal DeepAgent.
+            # path: it builds once against a symbolic Input (LM-free) and
+            # gives the subagent the same lifecycle as a top-level DeepAgent.
             inputs = Input(data_model=ChatMessages)
             outputs = await subagent(inputs)
             program = Program(

--- a/synalinks/src/modules/agents/function_calling_agent_test.py
+++ b/synalinks/src/modules/agents/function_calling_agent_test.py
@@ -2,8 +2,8 @@
 
 import json
 import os
-import warnings
 import tempfile
+import warnings
 from unittest.mock import patch
 
 from synalinks.src import testing
@@ -958,9 +958,10 @@ class FunctionCallingAgentTest(testing.TestCase):
             workdir=workdir,
         )
 
-        # Two interactive turns: the first makes three LM calls (tool call ->
-        # post-tool reply -> final), the second makes two. All five are scripted
-        # so no call falls into the (mocked) retry path.
+        # Two interactive turns: the first makes one LM call (a tool call,
+        # handed back to the caller), the second makes two (post-tool reply ->
+        # final). All three are scripted so no call falls into the (mocked)
+        # retry path. Auto-build traces on symbolic inputs, so it consumes none.
         mock_completion.side_effect = [
             _lm_response(
                 content="Calculating.",
@@ -968,8 +969,6 @@ class FunctionCallingAgentTest(testing.TestCase):
             ),
             _lm_response(content="No more tools."),
             _lm_response(content="Done: 1 + 1 = 2."),
-            _lm_response(content="Following up."),
-            _lm_response(content="Done again."),
         ]
 
         input_messages = ChatMessages(
@@ -979,7 +978,7 @@ class FunctionCallingAgentTest(testing.TestCase):
         # Two interactive turns, feeding the trajectory back into the agent.
         result = await agent(input_messages)
         result = await agent(result)
-        self.assertEqual(mock_completion.call_count, 5)
+        self.assertEqual(mock_completion.call_count, 3)
 
         messages = result.get("messages", [])
         agents_md_count = sum(
@@ -1048,9 +1047,10 @@ class FunctionCallingAgentTest(testing.TestCase):
             skills=[root],
         )
 
-        # Two interactive turns: the first turn makes three LM calls (tool
-        # call -> post-tool reply -> final), the second makes two. All five are
-        # scripted so no call falls into the (mocked) retry path.
+        # Two interactive turns: the first makes one LM call (a tool call,
+        # handed back to the caller), the second makes two (post-tool reply ->
+        # final). All three are scripted so no call falls into the (mocked)
+        # retry path. Auto-build traces on symbolic inputs, so it consumes none.
         mock_completion.side_effect = [
             _lm_response(
                 content="Calculating.",
@@ -1058,8 +1058,6 @@ class FunctionCallingAgentTest(testing.TestCase):
             ),
             _lm_response(content="No more tools."),
             _lm_response(content="Done."),
-            _lm_response(content="Following up."),
-            _lm_response(content="Done again."),
         ]
 
         input_messages = ChatMessages(
@@ -1067,7 +1065,7 @@ class FunctionCallingAgentTest(testing.TestCase):
         )
         result = await agent(input_messages)
         result = await agent(result)
-        self.assertEqual(mock_completion.call_count, 5)
+        self.assertEqual(mock_completion.call_count, 3)
 
         messages = result.get("messages", [])
         skills_count = sum(
@@ -1180,9 +1178,7 @@ class TruncatedGenerationTest(testing.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            await agent(
-                ChatMessages(messages=[ChatMessage(role="user", content="hi")])
-            )
+            await agent(ChatMessages(messages=[ChatMessage(role="user", content="hi")]))
 
         # One turn (not retried three times), then the final generator.
         self.assertEqual(mock_completion.call_count, 2)

--- a/synalinks/src/modules/agents/rlm_agent.py
+++ b/synalinks/src/modules/agents/rlm_agent.py
@@ -1042,8 +1042,8 @@ class RecursiveLanguageModelAgent(FunctionCallingAgent):
                     autonomous=True,
                     name=f"{self.name}_sub{index}",
                 )
-                # Run through a Program (the canonical path) so the subagent's
-                # build is LM-free and it isn't double-invoked.
+                # Run through a Program (the canonical path): it builds once
+                # against a symbolic Input and gets the standard lifecycle.
                 inp = Input(data_model=ChatMessages)
                 out = await subagent(inp)
                 program = Program(

--- a/synalinks/src/modules/module.py
+++ b/synalinks/src/modules/module.py
@@ -854,12 +854,21 @@ class Module(BackendModule, Operation, SynalinksSaveable):
         # Otherwise, attempt to build the module by calling it on symbolic input.
         if might_have_unbuilt_state(self):
             try:
+                # Trace on *symbolic* inputs: an eager call hands us concrete
+                # `JsonDataModel`s, and tracing `call()` on those would run the
+                # real forward pass (e.g. an LM request in `Generator`) just to
+                # discover the output schema. Converting first keeps the build
+                # purely symbolic, exactly like the functional API path.
+                symbolic_arguments = tree.map_structure(
+                    lambda x: (
+                        x.to_symbolic_data_model() if backend.is_json_data_model(x) else x
+                    ),
+                    call_spec.arguments_dict,
+                )
                 if not utils.is_default(self.compute_output_spec):
-                    await self.compute_output_spec(**call_spec.arguments_dict)
+                    await self.compute_output_spec(**symbolic_arguments)
                 else:
-                    await backend.compute_output_spec(
-                        self.call, **call_spec.arguments_dict
-                    )
+                    await backend.compute_output_spec(self.call, **symbolic_arguments)
             except Exception as e:
                 if call_spec.eager:
                     # Will let the actual eager call do state-building

--- a/synalinks/src/modules/module_test.py
+++ b/synalinks/src/modules/module_test.py
@@ -145,3 +145,52 @@ class ModuleTest(testing.TestCase):
         # `training` is captured per-call and must not leak between siblings.
         self.assertTrue(a.observed["training_seen"])
         self.assertFalse(b.observed["training_seen"])
+
+    async def test_auto_build_traces_on_symbolic_inputs_for_eager_calls(self):
+        """Auto-build must not run the real forward pass on concrete inputs.
+
+        An eager call on a module with unbuilt sub-modules triggers a trace
+        of `call()` to discover the output schema. That trace has to happen
+        on *symbolic* inputs; otherwise a module like `Generator` would issue
+        a real LM request just to build itself, then another for the actual
+        call.
+        """
+
+        class Query(backend.DataModel):
+            query: str
+
+        class Inner(modules.Module):
+            async def call(self, inputs):
+                return inputs
+
+            async def compute_output_spec(self, inputs):
+                return inputs
+
+        class Outer(modules.Module):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.inner = Inner()
+                self.concrete_calls = 0
+                self.symbolic_calls = 0
+
+            async def call(self, inputs):
+                if backend.is_symbolic_data_model(inputs):
+                    self.symbolic_calls += 1
+                else:
+                    self.concrete_calls += 1
+                return await self.inner(inputs)
+
+        outer = Outer()
+        self.assertFalse(outer.built)
+        result = await outer(Query(query="a").to_json_data_model())
+        self.assertTrue(outer.built)
+        self.assertTrue(outer.inner.built)
+        self.assertEqual(result.get("query"), "a")
+        # One symbolic trace for the build, one concrete run for the call.
+        self.assertEqual(outer.symbolic_calls, 1)
+        self.assertEqual(outer.concrete_calls, 1)
+
+        # Subsequent eager calls don't re-trace.
+        await outer(Query(query="b").to_json_data_model())
+        self.assertEqual(outer.symbolic_calls, 1)
+        self.assertEqual(outer.concrete_calls, 2)

--- a/synalinks/src/modules/ttc/self_critique.py
+++ b/synalinks/src/modules/ttc/self_critique.py
@@ -1,10 +1,20 @@
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
 
+import copy
+
 from synalinks.src.api_export import synalinks_export
 from synalinks.src.backend import DataModel
 from synalinks.src.backend import Field
+from synalinks.src.backend import JsonDataModel
 from synalinks.src.backend import Score
+from synalinks.src.backend import SymbolicDataModel
+from synalinks.src.backend import is_symbolic_data_model
+from synalinks.src.backend.pydantic.metrics import get_score_type
+from synalinks.src.backend.pydantic.metrics import normalize_score
+from synalinks.src.backend.pydantic.metrics import score_type_description
+from synalinks.src.backend.pydantic.metrics import score_type_json_type
+from synalinks.src.backend.pydantic.metrics import serialize_score_type
 from synalinks.src.modules.core.generator import Generator
 from synalinks.src.modules.language_models import get as _get_lm
 from synalinks.src.modules.module import Module
@@ -30,6 +40,88 @@ class CritiqueWithReward(DataModel):
     )
 
 
+_NORMALIZED_REWARD_SCHEMA = {
+    "title": "Reward",
+    "type": "number",
+    "minimum": 0.0,
+    "maximum": 1.0,
+    "description": (
+        "The reward value corresponding to the critique, "
+        "normalized between 0.0 (very bad) and 1.0 (very good)"
+    ),
+}
+
+
+def critique_with_reward_schema(score_type):
+    """Build the `CritiqueWithReward` schema for a given score type.
+
+    The `reward` property is replaced by an inline enum of the members of
+    `score_type` (e.g. `[1, 2, 3, 4, 5]` for `Rating`) so the language
+    model picks a value on that scale; `$defs` from the default `Score`
+    field are dropped so the schema stays self-contained.
+
+    Args:
+        score_type (type | str): The score scale (see `get_score_type`).
+
+    Returns:
+        (dict): The JSON schema handed to the underlying `Generator`.
+    """
+    score_type = get_score_type(score_type)
+    schema = copy.deepcopy(CritiqueWithReward.get_schema())
+    schema.pop("$defs", None)
+    schema["properties"]["reward"] = {
+        "title": "Reward",
+        "type": score_type_json_type(score_type),
+        "enum": [member.value for member in score_type],
+        "description": (
+            "The reward value corresponding to the critique "
+            f"({score_type_description(score_type)})"
+        ),
+    }
+    return schema
+
+
+def default_critique_instructions(score_type=None, return_reward=True):
+    """Return the default instructions of `SelfCritique` for a score scale.
+
+    The instructions spell out the grading scale in plain words (e.g. "an
+    integer between 1 and 5, 1 being very bad and 5 very good") so the
+    language model knows what the `reward` means even when the output schema
+    is not included in the prompt (`use_outputs_schema=False`, the default).
+
+    Args:
+        score_type (type | str): The score scale (see `get_score_type`).
+        return_reward (bool): Whether a `reward` is requested alongside the
+            critique; without it the instructions only ask for the critique.
+
+    Returns:
+        (str): The instructions string.
+    """
+    if not return_reward:
+        return (
+            "Your task is to carefully examine the provided inputs and write "
+            "an elaborated critique of them."
+        )
+    return (
+        "Your task is to carefully examine the provided inputs and write an "
+        "elaborated critique of them, then grade them with a reward. The reward "
+        f"is {score_type_description(score_type)}."
+    )
+
+
+def _normalized_reward_schema(schema):
+    """Return a copy of `schema` whose `reward` property is a 0..1 float."""
+    schema = copy.deepcopy(schema)
+    schema.setdefault("properties", {})["reward"] = dict(_NORMALIZED_REWARD_SCHEMA)
+    # Drop the default `Score` definition if nothing references it anymore.
+    defs = schema.get("$defs")
+    if defs and "Score" in defs:
+        defs.pop("Score")
+        if not defs:
+            schema.pop("$defs")
+    return schema
+
+
 @synalinks_export(
     [
         "synalinks.modules.SelfCritique",
@@ -44,6 +136,15 @@ class SelfCritique(Module):
 
     You can enable or disable the intermediate reward computation by
     using the `return_reward` flag (default to True).
+
+    The scale the language model picks the reward from is controlled by
+    `score_type`: `synalinks.Score` (default, 11 float levels), a finer
+    `synalinks.FineScore` (21 levels), or an integer Likert-style
+    `synalinks.Rating` (1 to 5), `synalinks.Rating10` (1 to 10) or
+    `synalinks.Rating20` (1 to 20). Whatever the scale, the `reward` in
+    the module's output is automatically normalized to a float between
+    0.0 (lowest level) and 1.0 (highest level), so downstream consumers
+    such as `ProgramAsJudge` / `LMAsJudge` always see a 0..1 reward.
 
     To have more accurate results, ensure that the inputs are provided along
     with the output to evaluate using `return_inputs` in your modules.
@@ -97,7 +198,9 @@ class SelfCritique(Module):
         examples (list): The default list of examples, the examples
             are a list of tuples containing input/output JSON pairs.
         instructions (str): The default instructions being a string containing
-            instructions for the language model.
+            instructions for the language model. If not provided, defaults to
+            `default_critique_instructions(score_type, return_reward)`, which
+            spells out the grading scale of `score_type`.
         seed_instructions (list): Optional. A list of instructions to use as seed for the
             optimization. If not provided, use the default instructions as seed.
         temperature (float): Optional. The temperature for the LM call.
@@ -115,6 +218,11 @@ class SelfCritique(Module):
         use_outputs_schema (bool): Optional. Whether or not use the outputs schema in
             the prompt (Default to False) (see `Generator`).
         return_reward (bool): Optional. Whether or not to compute an intermediate reward.
+        score_type (type | str): Optional. The scale the language model picks the
+            reward from: `synalinks.Score` (default), `synalinks.FineScore`,
+            `synalinks.Rating`, `synalinks.Rating10`, `synalinks.Rating20`, any
+            `Enum` whose members are `int` or `float`, or the name of one of them.
+            The output `reward` is always normalized to a float between 0.0 and 1.0.
         return_inputs (bool): Optional. Whether or not to concatenate the inputs to
             the outputs (Default to True) (see `Generator`).
         name (str): Optional. The name of the module.
@@ -138,6 +246,7 @@ class SelfCritique(Module):
         use_inputs_schema=False,
         use_outputs_schema=False,
         return_reward=True,
+        score_type=None,
         return_inputs=True,
         name=None,
         description=None,
@@ -149,8 +258,13 @@ class SelfCritique(Module):
             trainable=trainable,
         )
         self.language_model = _get_lm(language_model)
+        self.score_type = get_score_type(score_type)
         self.prompt_template = prompt_template
         self.examples = examples
+        if instructions is None:
+            instructions = default_critique_instructions(
+                self.score_type, return_reward=return_reward
+            )
         self.instructions = instructions
         self.seed_instructions = seed_instructions
         self.temperature = temperature
@@ -164,7 +278,7 @@ class SelfCritique(Module):
         self.return_inputs = return_inputs
 
         if self.return_reward:
-            schema = CritiqueWithReward.get_schema()
+            schema = critique_with_reward_schema(self.score_type)
         else:
             schema = Critique.get_schema()
 
@@ -187,10 +301,29 @@ class SelfCritique(Module):
         )
 
     async def call(self, inputs, training=False):
-        return await self.generator(inputs, training=training)
+        outputs = await self.generator(inputs, training=training)
+        if outputs is None or not self.return_reward:
+            return outputs
+        return self._normalize_reward(outputs)
+
+    def _normalize_reward(self, outputs):
+        """Rewrite `reward` from the native `score_type` scale to a 0..1 float.
+
+        The underlying generator keeps working in the native scale (so its
+        schema, prompt and recorded training predictions stay consistent);
+        only the module's output is normalized.
+        """
+        schema = _normalized_reward_schema(outputs.get_schema())
+        if is_symbolic_data_model(outputs):
+            return SymbolicDataModel(schema=schema, name=outputs.name)
+        json = dict(outputs.get_json())
+        if json.get("reward") is not None:
+            json["reward"] = normalize_score(json["reward"], self.score_type)
+        return JsonDataModel(json=json, schema=schema, name=outputs.name)
 
     def get_config(self):
         config = {
+            "score_type": serialize_score_type(self.score_type),
             "prompt_template": self.prompt_template,
             "examples": self.examples,
             "instructions": self.instructions,

--- a/synalinks/src/modules/ttc/self_critique_test.py
+++ b/synalinks/src/modules/ttc/self_critique_test.py
@@ -6,6 +6,10 @@ from unittest.mock import patch
 from synalinks.src import testing
 from synalinks.src.backend import DataModel
 from synalinks.src.backend import Field
+from synalinks.src.backend import FineScore
+from synalinks.src.backend import Rating
+from synalinks.src.backend import Rating20
+from synalinks.src.backend import Score
 from synalinks.src.modules.core.input_module import Input
 from synalinks.src.modules.language_models import LanguageModel
 from synalinks.src.modules.ttc.chain_of_thought import ChainOfThought
@@ -91,3 +95,132 @@ class SelfCritiqueModuleTest(testing.TestCase):
         )
 
         self.assertEqual(result.get_json(), json.loads(expected_string))
+
+    @patch("litellm.acompletion")
+    async def test_self_critique_with_rating_score_type(self, mock_completion):
+        class Answer(DataModel):
+            answer: str = Field(description="The answer")
+
+        language_model = LanguageModel(model="ollama/mistral")
+
+        critique = SelfCritique(
+            language_model=language_model,
+            score_type=Rating,
+        )
+        # The generator asks the LM for the native 1..5 integer scale.
+        reward_schema = critique.generator.schema["properties"]["reward"]
+        self.assertEqual(reward_schema["type"], "integer")
+        self.assertEqual(reward_schema["enum"], [1, 2, 3, 4, 5])
+        self.assertNotIn("$defs", critique.generator.schema)
+
+        # Symbolic output spec: `reward` is a normalized 0..1 float.
+        x0 = Input(data_model=Answer)
+        x1 = await critique(x0)
+        symbolic_reward = x1.get_schema()["properties"]["reward"]
+        self.assertEqual(symbolic_reward["type"], "number")
+        self.assertEqual(symbolic_reward["minimum"], 0.0)
+        self.assertEqual(symbolic_reward["maximum"], 1.0)
+        self.assertNotIn("$defs", x1.get_schema())
+
+        mock_completion.return_value = {
+            "choices": [
+                {"message": {"content": '{"critique": "Mostly right.", "reward": 4}'}}
+            ]
+        }
+        result = await critique(Answer(answer="Toulouse"))
+        self.assertEqual(result.get("critique"), "Mostly right.")
+        # 4 on a 1..5 scale is normalized to (4 - 1) / (5 - 1) = 0.75
+        self.assertAlmostEqual(result.get("reward"), 0.75)
+        self.assertEqual(result.get_schema()["properties"]["reward"]["type"], "number")
+
+    @patch("litellm.acompletion")
+    async def test_self_critique_with_fine_score_type_name(self, mock_completion):
+        class Answer(DataModel):
+            answer: str = Field(description="The answer")
+
+        language_model = LanguageModel(model="ollama/mistral")
+        # The score type can also be given by name.
+        critique = SelfCritique(
+            language_model=language_model,
+            score_type="FineScore",
+            return_inputs=False,
+        )
+        self.assertIs(critique.score_type, FineScore)
+        self.assertEqual(
+            critique.generator.schema["properties"]["reward"]["enum"][:3],
+            [0.0, 0.05, 0.1],
+        )
+        mock_completion.return_value = {
+            "choices": [{"message": {"content": '{"critique": "ok", "reward": 0.85}'}}]
+        }
+        result = await critique(Answer(answer="x"))
+        self.assertAlmostEqual(result.get("reward"), 0.85)
+
+    def test_self_critique_score_type_config_round_trip(self):
+        language_model = LanguageModel(model="ollama/mistral")
+        critique = SelfCritique(language_model=language_model, score_type=Rating20)
+        config = critique.get_config()
+        self.assertEqual(config["score_type"], "Rating20")
+        clone = SelfCritique.from_config(config)
+        self.assertIs(clone.score_type, Rating20)
+        self.assertEqual(
+            clone.generator.schema["properties"]["reward"]["enum"],
+            list(range(1, 21)),
+        )
+
+    def test_self_critique_default_score_type(self):
+        language_model = LanguageModel(model="ollama/mistral")
+        critique = SelfCritique(language_model=language_model)
+        self.assertIs(critique.score_type, Score)
+        self.assertEqual(critique.get_config()["score_type"], "Score")
+
+    def test_self_critique_default_instructions_spell_out_scale(self):
+        language_model = LanguageModel(model="ollama/mistral")
+        # Default 0.0..1.0 `Score`.
+        critique = SelfCritique(language_model=language_model)
+        self.assertIn("a float between 0.0 and 1.0", critique.instructions)
+        self.assertIn("1.0 very good", critique.instructions)
+        self.assertEqual(critique.generator.instructions, critique.instructions)
+        # Integer Likert-style scale: the instructions must name its bounds.
+        critique = SelfCritique(language_model=language_model, score_type=Rating)
+        self.assertIn("an integer between 1 and 5", critique.instructions)
+        self.assertIn("5 very good", critique.instructions)
+        # Without a reward only the critique is requested.
+        critique = SelfCritique(language_model=language_model, return_reward=False)
+        self.assertNotIn("reward", critique.instructions)
+        # User-provided instructions always win.
+        critique = SelfCritique(
+            language_model=language_model,
+            score_type=Rating,
+            instructions="Grade harshly.",
+        )
+        self.assertEqual(critique.instructions, "Grade harshly.")
+        self.assertEqual(critique.generator.instructions, "Grade harshly.")
+
+    def test_self_critique_invalid_score_type(self):
+        language_model = LanguageModel(model="ollama/mistral")
+        with self.assertRaises(ValueError):
+            SelfCritique(language_model=language_model, score_type="NotAScale")
+        with self.assertRaises(ValueError):
+            SelfCritique(language_model=language_model, score_type=str)
+
+    @patch("litellm.acompletion")
+    async def test_self_critique_eager_first_call_traces_symbolically(
+        self, mock_completion
+    ):
+        # Regression: the first eager call of an unbuilt module used to trace
+        # `call()` on the concrete inputs, costing one real LM request whose
+        # result was discarded. The build must be symbolic: one LM call total.
+        class Answer(DataModel):
+            answer: str = Field(description="The answer")
+
+        language_model = LanguageModel(model="ollama/mistral")
+        critique = SelfCritique(language_model=language_model, return_inputs=False)
+        self.assertFalse(critique.built)
+        mock_completion.return_value = {
+            "choices": [{"message": {"content": '{"critique": "ok", "reward": 0.9}'}}]
+        }
+        result = await critique(Answer(answer="Toulouse"))
+        self.assertTrue(critique.built)
+        self.assertEqual(mock_completion.call_count, 1)
+        self.assertAlmostEqual(result.get("reward"), 0.9)

--- a/synalinks/src/rewards/lm_as_judge.py
+++ b/synalinks/src/rewards/lm_as_judge.py
@@ -2,6 +2,8 @@
 
 from synalinks.src import ops
 from synalinks.src.api_export import synalinks_export
+from synalinks.src.backend.pydantic.metrics import get_score_type
+from synalinks.src.backend.pydantic.metrics import serialize_score_type
 from synalinks.src.modules import SelfCritique
 from synalinks.src.modules.ttc.self_critique import CritiqueWithReward
 from synalinks.src.programs import Program
@@ -19,6 +21,8 @@ class LMAsJudgeProgram(Program):
         examples (list): The default examples to use in the prompt
             (see `Generator`).
         instructions (list): The default instructions to use (see `Generator`).
+        score_type (type | str): Optional. The scale the judge picks the reward
+            from (see `SelfCritique`); the reward is normalized to 0.0..1.0.
         name (str): Optional. The name of the program.
         description (str): Optional. The description of the program.
         trainable (bool): Whether the program's variables should be trainable.
@@ -30,6 +34,7 @@ class LMAsJudgeProgram(Program):
         prompt_template=None,
         examples=None,
         instructions=None,
+        score_type=None,
         name=None,
         description=None,
         trainable=True,
@@ -39,11 +44,13 @@ class LMAsJudgeProgram(Program):
             description=description,
             trainable=trainable,
         )
+        self.score_type = get_score_type(score_type)
         self.critique = SelfCritique(
             language_model=language_model,
             prompt_template=prompt_template,
             examples=examples,
             instructions=instructions,
+            score_type=self.score_type,
             name="self_critique_" + self.name,
         )
         self.language_model = language_model
@@ -87,6 +94,7 @@ class LMAsJudgeProgram(Program):
             "prompt_template": self.prompt_template,
             "examples": self.examples,
             "instructions": self.instructions,
+            "score_type": serialize_score_type(self.score_type),
             "name": self.name,
             "description": self.description,
             "trainable": self.trainable,
@@ -125,6 +133,10 @@ class LMAsJudge(ProgramAsJudge):
         program.compile(
             reward=synalinks.rewards.LMAsJudge(
                 language_model=language_model,
+                # Optional: let the judge grade on a 1..5 integer scale
+                # instead of the default 0.0..1.0 `Score`. The reward
+                # is normalized back to 0.0..1.0 automatically.
+                score_type=synalinks.Rating,
             )
             optimizer=synalinks.optimizers.RandomFewShot(),
         )
@@ -140,6 +152,11 @@ class LMAsJudge(ProgramAsJudge):
         instructions (list): The default instructions to use (see `Generator`).
         examples (list): The default examples to use in the prompt
             (see `Generator`).
+        score_type (type | str): Optional. The scale the judge picks the reward
+            from: `synalinks.Score` (default), `synalinks.FineScore`,
+            `synalinks.Rating`, `synalinks.Rating10`, `synalinks.Rating20`, any
+            `Enum` whose members are `int` or `float`, or the name of one of them.
+            The reward is always normalized to a float between 0.0 and 1.0.
         name (str): Optional. string name of the reward instance.
         in_mask (list): Optional. list of keys to keep to compute the reward.
         out_mask (list): Optional. list of keys to remove to compute the reward.
@@ -155,6 +172,7 @@ class LMAsJudge(ProgramAsJudge):
         prompt_template=None,
         examples=None,
         instructions=None,
+        score_type=None,
         name="lm_as_judge",
         in_mask=None,
         out_mask=None,
@@ -166,6 +184,7 @@ class LMAsJudge(ProgramAsJudge):
             prompt_template=prompt_template,
             examples=examples,
             instructions=instructions,
+            score_type=score_type,
         )
         super().__init__(
             program=program,

--- a/synalinks/src/rewards/lm_as_judge_test.py
+++ b/synalinks/src/rewards/lm_as_judge_test.py
@@ -5,8 +5,10 @@ from unittest.mock import patch
 from synalinks.src import testing
 from synalinks.src.backend import DataModel
 from synalinks.src.backend import Field
+from synalinks.src.backend import Rating10
 from synalinks.src.modules.language_models import LanguageModel
 from synalinks.src.rewards.lm_as_judge import LMAsJudge
+from synalinks.src.rewards.lm_as_judge import LMAsJudgeProgram
 
 
 class LMAsJudgeTest(testing.TestCase):
@@ -70,3 +72,63 @@ class LMAsJudgeTest(testing.TestCase):
         score = await reward(y_true=y_true, y_pred=None)
         self.assertEqual(score, 0.0)
         mock_completion.assert_not_called()
+
+    @patch("litellm.acompletion")
+    async def test_lm_as_judge_with_rating10_score_type(self, mock_completion):
+        class Answer(DataModel):
+            answer: str = Field(description="The correct answer")
+
+        language_model = LanguageModel(model="ollama/mistral")
+        reward = LMAsJudge(language_model=language_model, score_type=Rating10)
+
+        # The judge asks the LM for a 1..10 integer...
+        reward_schema = reward.program.critique.generator.schema["properties"]["reward"]
+        self.assertEqual(reward_schema["type"], "integer")
+        self.assertEqual(reward_schema["enum"], list(range(1, 11)))
+
+        mock_completion.return_value = {
+            "choices": [
+                {"message": {"content": '{"critique": "Close enough.", "reward": 7}'}}
+            ]
+        }
+        score = await reward(y_true=Answer(answer="Paris"), y_pred=Answer(answer="paris"))
+        # ...and the reward is normalized: (7 - 1) / (10 - 1)
+        self.assertAlmostEqual(score, 6 / 9)
+
+    @patch("litellm.acompletion")
+    async def test_lm_as_judge_score_type_bounds(self, mock_completion):
+        class Answer(DataModel):
+            answer: str = Field(description="The correct answer")
+
+        language_model = LanguageModel(model="ollama/mistral")
+        reward = LMAsJudge(language_model=language_model, score_type="Rating")
+
+        # Exactly one LM call per evaluation, including the very first one:
+        # building the judge program must trace symbolically, not call the LM.
+        mock_completion.side_effect = [
+            {"choices": [{"message": {"content": '{"critique": "bad", "reward": 1}'}}]},
+            {"choices": [{"message": {"content": '{"critique": "top", "reward": 5}'}}]},
+        ]
+        low = await reward(y_true=Answer(answer="a"), y_pred=Answer(answer="b"))
+        high = await reward(y_true=Answer(answer="a"), y_pred=Answer(answer="a"))
+        self.assertEqual(low, 0.0)
+        self.assertEqual(high, 1.0)
+        self.assertEqual(mock_completion.call_count, 2)
+
+    def test_lm_as_judge_default_instructions_follow_score_type(self):
+        language_model = LanguageModel(model="ollama/mistral")
+        reward = LMAsJudge(language_model=language_model, score_type=Rating10)
+        instructions = reward.program.critique.instructions
+        self.assertIn("an integer between 1 and 10", instructions)
+        self.assertIn("10 very good", instructions)
+        reward = LMAsJudge(language_model=language_model)
+        self.assertIn("a float between 0.0 and 1.0", reward.program.critique.instructions)
+
+    def test_lm_as_judge_score_type_config_round_trip(self):
+        language_model = LanguageModel(model="ollama/mistral")
+        reward = LMAsJudge(language_model=language_model, score_type=Rating10)
+        config = reward.program.get_config()
+        self.assertEqual(config["score_type"], "Rating10")
+        program = LMAsJudgeProgram.from_config(config)
+        self.assertIs(program.score_type, Rating10)
+        self.assertIs(program.critique.score_type, Rating10)


### PR DESCRIPTION
## Summary

- **Configurable score scales** for `SelfCritique` and `LMAsJudge` via a new `score_type` argument. Alongside the existing 0.0..1.0 `Score`, the pydantic metrics backend now ships `FineScore` (21 float levels), `Rating` (1..5), `Rating10` (1..10) and `Rating20` (1..20), plus `get_score_type` / `normalize_score` helpers (exported as `synalinks.Rating`, etc.). The generator's `reward` property becomes an inline enum of the scale, the default instructions spell out the scale in words, and the emitted reward is always normalized back to 0.0..1.0 so downstream rewards/metrics are unchanged. Round-trips through `get_config`/`from_config`.
- **Fix: auto-build no longer hits the LM on eager calls.** `Module._maybe_build` now converts concrete `JsonDataModel` arguments to `SymbolicDataModel` before tracing, so modules wrapping a `Generator` (agents in particular) stop issuing throwaway LM requests just to discover their output schema. Two agent tests were only passing because the build silently consumed their first two scripted mock responses; they now script the real 3-call sequence. Regression test added in `module_test.py`.
- Version bump to 0.9.014 + `uv.lock` refresh.

## Test plan

- [x] `uv run pytest synalinks`: 2215 passed, 9 skipped (full suite, pre default-instructions change)
- [x] `synalinks/src/modules/ttc`, `synalinks/src/rewards`, `backend/pydantic/metrics_test.py`, `modules/core/generator_test.py`: 101 passed after the default-instructions change
- [x] Regression test `test_auto_build_traces_on_symbolic_inputs_for_eager_calls` verified to fail on the old `_maybe_build`
- [x] `ruff` + `black -l 90` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
