### PR TITLE
docs: document the score scales (FineScore, Rating, Rating10, Rating20)

### DIFF
--- a/docs/Code Examples/Autonomous Agent.md
+++ b/docs/Code Examples/Autonomous Agent.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/10_autonomous_agent.py:108"
+--8<-- "examples/10_autonomous_agent.py:108"
 ````
 
 ## Run log

--- a/docs/Code Examples/Conditional Branches.md
+++ b/docs/Code Examples/Conditional Branches.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/4_conditional_branches.py:129"
+--8<-- "examples/4_conditional_branches.py:129"
 ````
 
 ## Run log

--- a/docs/Code Examples/Conversational Applications.md
+++ b/docs/Code Examples/Conversational Applications.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/6_conversational_applications.py:83"
+--8<-- "examples/6_conversational_applications.py:83"
 ````
 
 ## Run log

--- a/docs/Code Examples/Cypher Agent.md
+++ b/docs/Code Examples/Cypher Agent.md
@@ -7,7 +7,7 @@
 ## Source
 
 ````python
---8 < --"examples/23_cypher_agent.py:source"
+--8<-- "examples/23_cypher_agent.py:source"
 ````
 
 ## Run log

--- a/docs/Code Examples/Data Model Operators.md
+++ b/docs/Code Examples/Data Model Operators.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/5a_data_model_operators.py:168"
+--8<-- "examples/5a_data_model_operators.py:168"
 ````
 
 ## Run log

--- a/docs/Code Examples/Decisions.md
+++ b/docs/Code Examples/Decisions.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/3_decisions.py:120"
+--8<-- "examples/3_decisions.py:120"
 ````
 
 ## Run log

--- a/docs/Code Examples/Deep Agent.md
+++ b/docs/Code Examples/Deep Agent.md
@@ -7,7 +7,7 @@
 ## Source
 
 ````python
---8 < --"examples/20_deep_agent.py:source"
+--8<-- "examples/20_deep_agent.py:source"
 ````
 
 ## Run log

--- a/docs/Code Examples/Document RAG.md
+++ b/docs/Code Examples/Document RAG.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/13_document_rag.py:89"
+--8<-- "examples/13_document_rag.py:89"
 ````
 
 ## Run log

--- a/docs/Code Examples/First Steps.md
+++ b/docs/Code Examples/First Steps.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/0_first_steps.py:135"
+--8<-- "examples/0_first_steps.py:135"
 ````
 
 ## Run log

--- a/docs/Code Examples/Functional API.md
+++ b/docs/Code Examples/Functional API.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/1a_functional_api.py:127"
+--8<-- "examples/1a_functional_api.py:127"
 ````
 
 ## Run log

--- a/docs/Code Examples/Implementing Custom Modules Via Subclassing.md
+++ b/docs/Code Examples/Implementing Custom Modules Via Subclassing.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/9_custom_modules.py:132"
+--8<-- "examples/9_custom_modules.py:132"
 ````
 
 ## Run log

--- a/docs/Code Examples/Interactive Agent.md
+++ b/docs/Code Examples/Interactive Agent.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/11_interactive_agent.py:132"
+--8<-- "examples/11_interactive_agent.py:132"
 ````
 
 ## Run log

--- a/docs/Code Examples/JSON Ops.md
+++ b/docs/Code Examples/JSON Ops.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/5b_json_ops.py:121"
+--8<-- "examples/5b_json_ops.py:121"
 ````
 
 ## Run log

--- a/docs/Code Examples/Knowledge Extraction and Storage.md
+++ b/docs/Code Examples/Knowledge Extraction and Storage.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/12_knowledge_extraction_and_storage.py:110"
+--8<-- "examples/12_knowledge_extraction_and_storage.py:110"
 ````
 
 ## Run log

--- a/docs/Code Examples/MCP Agent.md
+++ b/docs/Code Examples/MCP Agent.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/15_mcp_agent.py:100"
+--8<-- "examples/15_mcp_agent.py:100"
 ````
 
 ## Run log

--- a/docs/Code Examples/Mixing Strategy.md
+++ b/docs/Code Examples/Mixing Strategy.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/1d_mixing_strategy.py:159"
+--8<-- "examples/1d_mixing_strategy.py:159"
 ````
 
 ## Run log

--- a/docs/Code Examples/Parallel Branches.md
+++ b/docs/Code Examples/Parallel Branches.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/2_parallel_branches.py:128"
+--8<-- "examples/2_parallel_branches.py:128"
 ````
 
 ## Run log

--- a/docs/Code Examples/Python Synthesis.md
+++ b/docs/Code Examples/Python Synthesis.md
@@ -7,5 +7,5 @@
 ## Source
 
 ````python
---8 < --"examples/22_python_synthesis.py:source"
+--8<-- "examples/22_python_synthesis.py:source"
 ````

--- a/docs/Code Examples/Recursive Language Model Agent.md
+++ b/docs/Code Examples/Recursive Language Model Agent.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/17_recursive_language_model_agent.py:128"
+--8<-- "examples/17_recursive_language_model_agent.py:128"
 ````
 
 ## Run log

--- a/docs/Code Examples/Reward Metrics And Optimizers.md
+++ b/docs/Code Examples/Reward Metrics And Optimizers.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/7_reward_metrics_and_optimizers.py:84"
+--8<-- "examples/7_reward_metrics_and_optimizers.py:84"
 ````
 
 ## Run log

--- a/docs/Code Examples/SQL Agent.md
+++ b/docs/Code Examples/SQL Agent.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/16_sql_agent.py:source"
+--8<-- "examples/16_sql_agent.py:source"
 ````
 
 ## Run log

--- a/docs/Code Examples/Sequential API.md
+++ b/docs/Code Examples/Sequential API.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/1c_sequential.py:109"
+--8<-- "examples/1c_sequential.py:109"
 ````
 
 ## Run log

--- a/docs/Code Examples/Subclassing.md
+++ b/docs/Code Examples/Subclassing.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"examples/1b_subclassing.py:158"
+--8<-- "examples/1b_subclassing.py:158"
 ````
 
 ## Run log

--- a/docs/Code Examples/Training Programs.md
+++ b/docs/Code Examples/Training Programs.md
@@ -8,5 +8,5 @@
 ## Source
 
 ````python
---8 < --"examples/8_training_programs.py:95"
+--8<-- "examples/8_training_programs.py:95"
 ````

--- a/docs/Code Examples/Vector RAG Agent.md
+++ b/docs/Code Examples/Vector RAG Agent.md
@@ -7,7 +7,7 @@
 ## Source
 
 ````python
---8 < --"examples/14_vector_rag_agent.py:source"
+--8<-- "examples/14_vector_rag_agent.py:source"
 ````
 
 ## Run log

--- a/docs/Synalinks API/Data Models API/Score Data Models.md
+++ b/docs/Synalinks API/Data Models API/Score Data Models.md
@@ -1,0 +1,1 @@
+::: synalinks.src.backend.pydantic.metrics

--- a/docs/Synalinks API/Data Models API/index.md
+++ b/docs/Synalinks API/Data Models API/index.md
@@ -17,3 +17,4 @@ Synalinks features four distinct types of data models, each serving a unique pur
 - [The SymbolicDataModel Class](The SymbolicDataModel class.md): The symbolic data models.
 - [The Variable Class](The Variable class.md): The variable data models that the optimizers can act upon.
 - [The Base DataModels](The Base DataModels.md): A collection of basic backend-dependent data models.
+- [Score Data Models](Score Data Models.md): Discretized score scales (`Score`, `FineScore`, `Rating`, `Rating10`, `Rating20`) the language model can pick from, and the helpers to resolve and normalize them.

--- a/docs/guides/Agents.md
+++ b/docs/guides/Agents.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/6_agents.py:446"
+--8<-- "guides/6_agents.py:446"
 ````
 
 ## Run log

--- a/docs/guides/Callbacks.md
+++ b/docs/guides/Callbacks.md
@@ -8,5 +8,5 @@
 ## Source
 
 ````python
---8 < --"guides/16_callbacks.py:401"
+--8<-- "guides/16_callbacks.py:401"
 ````

--- a/docs/guides/Consul of Models.md
+++ b/docs/guides/Consul of Models.md
@@ -7,7 +7,7 @@
 ## Source
 
 ````python
---8 < --"guides/30_consul_of_models.py:364"
+--8<-- "guides/30_consul_of_models.py:364"
 ````
 
 ## Run log

--- a/docs/guides/Control Flow.md
+++ b/docs/guides/Control Flow.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/5_control_flow.py:255"
+--8<-- "guides/5_control_flow.py:255"
 ````
 
 ## Run log

--- a/docs/guides/Cypher Agent.md
+++ b/docs/guides/Cypher Agent.md
@@ -7,7 +7,7 @@
 ## Source
 
 ````python
---8 < --"guides/26_cypher_agent.py:101"
+--8<-- "guides/26_cypher_agent.py:101"
 ````
 
 ## Run log

--- a/docs/guides/Data Models.md
+++ b/docs/guides/Data Models.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/2_data_models.py:541"
+--8 < --"guides/2_data_models.py:558"
 ````
 
 ## Run log

--- a/docs/guides/Data Models.md
+++ b/docs/guides/Data Models.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/2_data_models.py:558"
+--8<-- "guides/2_data_models.py:558"
 ````
 
 ## Run log

--- a/docs/guides/Datasets.md
+++ b/docs/guides/Datasets.md
@@ -8,5 +8,5 @@
 ## Source
 
 ````python
---8 < --"guides/11_datasets.py:435"
+--8<-- "guides/11_datasets.py:435"
 ````

--- a/docs/guides/Deep Agent.md
+++ b/docs/guides/Deep Agent.md
@@ -7,7 +7,7 @@
 ## Source
 
 ````python
---8 < --"guides/22_deep_agent.py:243"
+--8<-- "guides/22_deep_agent.py:247"
 ````
 
 ## Run log

--- a/docs/guides/FastAPI Deployment.md
+++ b/docs/guides/FastAPI Deployment.md
@@ -8,5 +8,5 @@
 ## Source
 
 ```python
---8 < --"guides/20_fastapi_deployment.py:source"
+--8<-- "guides/20_fastapi_deployment.py:source"
 ```

--- a/docs/guides/FastMCP Deployment.md
+++ b/docs/guides/FastMCP Deployment.md
@@ -8,5 +8,5 @@
 ## Source
 
 ```python
---8 < --"guides/21_fastmcp_deployment.py:source"
+--8<-- "guides/21_fastmcp_deployment.py:source"
 ```

--- a/docs/guides/Free-form Knowledge Graph Extraction.md
+++ b/docs/guides/Free-form Knowledge Graph Extraction.md
@@ -7,7 +7,7 @@
 ## Source
 
 ````python
---8 < --"guides/28_free_form_knowledge_graph_extraction.py:source"
+--8<-- "guides/28_free_form_knowledge_graph_extraction.py:source"
 ````
 
 ## Run log

--- a/docs/guides/Getting Started.md
+++ b/docs/guides/Getting Started.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/1_getting_started.py:345"
+--8<-- "guides/1_getting_started.py:345"
 ````
 
 ## Run log

--- a/docs/guides/GraphRAG.md
+++ b/docs/guides/GraphRAG.md
@@ -7,7 +7,7 @@
 ## Source
 
 ````python
---8 < --"guides/32_graphrag.py:source"
+--8<-- "guides/32_graphrag.py:source"
 ````
 
 ## Run log

--- a/docs/guides/Hyperparameter Search.md
+++ b/docs/guides/Hyperparameter Search.md
@@ -8,5 +8,5 @@
 ## Source
 
 ````python
---8 < --"guides/17_hyperparameter_search.py:351"
+--8<-- "guides/17_hyperparameter_search.py:351"
 ````

--- a/docs/guides/Input Guard.md
+++ b/docs/guides/Input Guard.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/8_input_guard.py:294"
+--8<-- "guides/8_input_guard.py:294"
 ````
 
 ## Run log

--- a/docs/guides/Knowledge Base.md
+++ b/docs/guides/Knowledge Base.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/7_knowledge_base.py:source"
+--8<-- "guides/7_knowledge_base.py:source"
 ````
 
 ## Run log

--- a/docs/guides/Knowledge Graph Extraction.md
+++ b/docs/guides/Knowledge Graph Extraction.md
@@ -7,7 +7,7 @@
 ## Source
 
 ````python
---8 < --"guides/27_knowledge_graph_extraction.py:source"
+--8<-- "guides/27_knowledge_graph_extraction.py:source"
 ````
 
 ## Run log

--- a/docs/guides/Metrics.md
+++ b/docs/guides/Metrics.md
@@ -8,5 +8,5 @@
 ## Source
 
 ````python
---8 < --"guides/14_metrics.py:345"
+--8<-- "guides/14_metrics.py:345"
 ````

--- a/docs/guides/Mixture of Models.md
+++ b/docs/guides/Mixture of Models.md
@@ -7,7 +7,7 @@
 ## Source
 
 ````python
---8 < --"guides/29_mixture_of_models.py:396"
+--8<-- "guides/29_mixture_of_models.py:396"
 ````
 
 ## Run log

--- a/docs/guides/Modules.md
+++ b/docs/guides/Modules.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/4_modules.py:635"
+--8 < --"guides/4_modules.py:641"
 ````
 
 ## Run log

--- a/docs/guides/Modules.md
+++ b/docs/guides/Modules.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/4_modules.py:641"
+--8<-- "guides/4_modules.py:641"
 ````
 
 ## Run log

--- a/docs/guides/Multi-Objective LM Selection.md
+++ b/docs/guides/Multi-Objective LM Selection.md
@@ -8,5 +8,5 @@
 ## Source
 
 ````python
---8 < --"guides/18_multi_objective_lm_selection.py:429"
+--8<-- "guides/18_multi_objective_lm_selection.py:429"
 ````

--- a/docs/guides/Multimodal Inputs.md
+++ b/docs/guides/Multimodal Inputs.md
@@ -7,7 +7,7 @@
 ## Source
 
 ````python
---8 < --"guides/31_multimodal.py:298"
+--8<-- "guides/31_multimodal.py:298"
 ````
 
 ## Run log

--- a/docs/guides/Observability.md
+++ b/docs/guides/Observability.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/10_observability.py:387"
+--8<-- "guides/10_observability.py:387"
 ````
 
 ## Run log

--- a/docs/guides/Output Guard.md
+++ b/docs/guides/Output Guard.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/9_output_guard.py:307"
+--8<-- "guides/9_output_guard.py:307"
 ````
 
 ## Run log

--- a/docs/guides/Programs.md
+++ b/docs/guides/Programs.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/3_programs.py:494"
+--8<-- "guides/3_programs.py:494"
 ````
 
 ## Run log

--- a/docs/guides/Python Synthesis.md
+++ b/docs/guides/Python Synthesis.md
@@ -8,5 +8,5 @@
 ## Source
 
 ````python
---8 < --"guides/25_python_synthesis.py:341"
+--8<-- "guides/25_python_synthesis.py:339"
 ````

--- a/docs/guides/Recursive Language Model Agent.md
+++ b/docs/guides/Recursive Language Model Agent.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/19_recursive_language_model_agent.py:576"
+--8<-- "guides/19_recursive_language_model_agent.py:591"
 ````
 
 ## Run log

--- a/docs/guides/Rewards.md
+++ b/docs/guides/Rewards.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/13_rewards.py:340"
+--8 < --"guides/13_rewards.py:356"
 ````
 
 ## Run log

--- a/docs/guides/Rewards.md
+++ b/docs/guides/Rewards.md
@@ -8,7 +8,7 @@
 ## Source
 
 ````python
---8 < --"guides/13_rewards.py:356"
+--8<-- "guides/13_rewards.py:356"
 ````
 
 ## Run log

--- a/docs/guides/SQL Agent.md
+++ b/docs/guides/SQL Agent.md
@@ -7,7 +7,7 @@
 ## Source
 
 ````python
---8 < --"guides/23_sql_agent.py:207"
+--8<-- "guides/23_sql_agent.py:207"
 ````
 
 ## Run log

--- a/docs/guides/Trainable Variables.md
+++ b/docs/guides/Trainable Variables.md
@@ -8,5 +8,5 @@
 ## Source
 
 ````python
---8 < --"guides/12_trainable_variables.py:500"
+--8<-- "guides/12_trainable_variables.py:500"
 ````

--- a/docs/guides/Training.md
+++ b/docs/guides/Training.md
@@ -8,5 +8,5 @@
 ## Source
 
 ````python
---8 < --"guides/15_training.py:444"
+--8<-- "guides/15_training.py:444"
 ````

--- a/docs/guides/Vector RAG Agent.md
+++ b/docs/guides/Vector RAG Agent.md
@@ -7,7 +7,7 @@
 ## Source
 
 ````python
---8 < --"guides/24_vector_rag_agent.py:246"
+--8<-- "guides/24_vector_rag_agent.py:246"
 ````
 
 ## Run log

--- a/guides/13_rewards.py
+++ b/guides/13_rewards.py
@@ -177,6 +177,22 @@ called `ProgramAsJudge`. The judge sees both `y_true` and
 returns a numeric score that the framework normalizes to
 `[0, 1]`.
 
+By default the judge picks from `synalinks.Score` (eleven values
+from 0.0 to 1.0). If your rubric reads more naturally as a
+rating, pass `score_type=synalinks.Rating` (1 to 5), `Rating10`,
+`Rating20` or `FineScore`:
+
+```python
+reward = synalinks.rewards.LMAsJudge(
+    language_model=judge_model,
+    score_type=synalinks.Rating,
+)
+```
+
+The judge's default instructions and output schema follow the
+chosen scale, and the reward is still normalized to `[0, 1]`,
+so optimizers and metrics see no difference.
+
 Three things to know about LM judges:
 
 - **They are the most flexible reward.** You can grade things

--- a/guides/2_data_models.py
+++ b/guides/2_data_models.py
@@ -183,6 +183,7 @@ trip:
 | `dict`            | object      | `{"key": "value"}`   |
 | `Enum`            | enum        | constrained choices  |
 | `synalinks.Score` | enum        | 0.0 to 1.0, step 0.1 |
+| `synalinks.Rating` | enum       | 1 to 5, integer      |
 
 If a Python type maps cleanly to JSON Schema, you can use it. You can
 also **nest** one data model inside another: the inner schema gets
@@ -261,6 +262,18 @@ Use `Score` for confidence, quality, similarity: anything that lives on
 a normalized scale. Do *not* use it when you genuinely need continuous
 values (for example, the target of a regression task); for that, declare
 the field as `float` and validate the range yourself.
+
+`Score` has a few siblings for when a 0.1 step is not the right grain.
+`synalinks.FineScore` splits the same `[0, 1]` range into twenty-one
+buckets (step 0.05). `synalinks.Rating`, `synalinks.Rating10` and
+`synalinks.Rating20` are integer, Likert-style scales (1 to 5, 1 to 10
+and 1 to 20) for rubrics that read more naturally as "4 out of 5" than
+as `0.8`. All of them are plain enums, so they work as field types exactly
+like `Score`. The modules that grade things (`SelfCritique` and the
+`LMAsJudge` reward) also accept any of them as `score_type` and normalize
+the picked value back to `[0, 1]`, so the rest of the pipeline never sees
+the difference; see [Guide 13](https://synalinks.github.io/synalinks/guides/Rewards/)
+for the reward side.
 
 ## Combining Data Models with Operators
 
@@ -526,7 +539,8 @@ If you remember nothing else from this guide, remember the following:
   whenever the answer should come from a small, fixed alphabet.
 - **`synalinks.Score` splits `[0, 1]` into ten meaningful buckets.**
   Use it for confidence/quality/similarity; reach for plain `float`
-  only when you genuinely need continuous values.
+  only when you genuinely need continuous values. `FineScore` and the
+  integer `Rating`/`Rating10`/`Rating20` scales cover other grains.
 - The **operators** (`+`, `&`, `|`, `^`, `~`) compose schemas without
   hand-written adapter classes, and the **masking helpers** (`in_mask`,
   `out_mask`) project onto subsets of fields.

--- a/guides/4_modules.py
+++ b/guides/4_modules.py
@@ -435,6 +435,12 @@ outputs = await synalinks.SelfCritique(
 )(inputs)
 ```
 
+By default the reward is a `synalinks.Score` (eleven values from 0.0 to
+1.0). Pass `score_type=synalinks.Rating` (1 to 5), `Rating10`, `Rating20`
+or `FineScore` to let the model grade on another scale: the module spells
+the scale out in its default instructions and in the output schema, and
+normalizes the picked value back to 0.0..1.0 before returning it.
+
 ## Complete Example
 
 ```python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
       - Synalinks API/Data Models API/The Base DataModels.md
       - Synalinks API/Data Models API/Knowledge Data Models.md
       - Synalinks API/Data Models API/Multimodal Data Models.md
+      - Synalinks API/Data Models API/Score Data Models.md
     - Programs API:
       - Synalinks API/Programs API/index.md
       - Synalinks API/Programs API/The Program class.md

--- a/notebooks/guides/data_models.ipynb
+++ b/notebooks/guides/data_models.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
     "# Data Models\n",
@@ -189,6 +188,7 @@
     "| `dict`            | object      | `{\"key\": \"value\"}`   |\n",
     "| `Enum`            | enum        | constrained choices  |\n",
     "| `synalinks.Score` | enum        | 0.0 to 1.0, step 0.1 |\n",
+    "| `synalinks.Rating` | enum       | 1 to 5, integer      |\n",
     "\n",
     "If a Python type maps cleanly to JSON Schema, you can use it. You can\n",
     "also **nest** one data model inside another: the inner schema gets\n",
@@ -267,6 +267,18 @@
     "a normalized scale. Do *not* use it when you genuinely need continuous\n",
     "values (for example, the target of a regression task); for that, declare\n",
     "the field as `float` and validate the range yourself.\n",
+    "\n",
+    "`Score` has a few siblings for when a 0.1 step is not the right grain.\n",
+    "`synalinks.FineScore` splits the same `[0, 1]` range into twenty-one\n",
+    "buckets (step 0.05). `synalinks.Rating`, `synalinks.Rating10` and\n",
+    "`synalinks.Rating20` are integer, Likert-style scales (1 to 5, 1 to 10\n",
+    "and 1 to 20) for rubrics that read more naturally as \"4 out of 5\" than\n",
+    "as `0.8`. All of them are plain enums, so they work as field types exactly\n",
+    "like `Score`. The modules that grade things (`SelfCritique` and the\n",
+    "`LMAsJudge` reward) also accept any of them as `score_type` and normalize\n",
+    "the picked value back to `[0, 1]`, so the rest of the pipeline never sees\n",
+    "the difference; see [Guide 13](https://synalinks.github.io/synalinks/guides/Rewards/)\n",
+    "for the reward side.\n",
     "\n",
     "## Combining Data Models with Operators\n",
     "\n",
@@ -532,7 +544,8 @@
     "  whenever the answer should come from a small, fixed alphabet.\n",
     "- **`synalinks.Score` splits `[0, 1]` into ten meaningful buckets.**\n",
     "  Use it for confidence/quality/similarity; reach for plain `float`\n",
-    "  only when you genuinely need continuous values.\n",
+    "  only when you genuinely need continuous values. `FineScore` and the\n",
+    "  integer `Rating`/`Rating10`/`Rating20` scales cover other grains.\n",
     "- The **operators** (`+`, `&`, `|`, `^`, `~`) compose schemas without\n",
     "  hand-written adapter classes, and the **masking helpers** (`in_mask`,\n",
     "  `out_mask`) project onto subsets of fields.\n",
@@ -549,7 +562,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
    "source": [
     "## Setup\n",
@@ -558,9 +570,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
+   "execution_count": null,
    "outputs": [],
    "source": [
     "# @title Setup: run me first\n",
@@ -570,7 +581,6 @@
     "# then pull the models it needs. Slow on a CPU runtime; prefer a GPU one.\n",
     "!curl -fsSL https://ollama.com/install.sh | sh\n",
     "import subprocess, time\n",
-    "\n",
     "subprocess.Popen([\"ollama\", \"serve\"])\n",
     "time.sleep(5)\n",
     "!ollama pull mistral:latest"
@@ -578,9 +588,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
+   "execution_count": null,
    "outputs": [],
    "source": [
     "import asyncio\n",
@@ -660,20 +669,20 @@
     "\n",
     "\n",
     "if __name__ == \"__main__\":\n",
-    "    asyncio.run(main())"
+    "    asyncio.run(main())\n"
    ]
   }
  ],
  "metadata": {
-  "colab": {
-   "provenance": []
-  },
   "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"
   },
   "language_info": {
    "name": "python"
+  },
+  "colab": {
+   "provenance": []
   }
  },
  "nbformat": 4,

--- a/notebooks/guides/modules.ipynb
+++ b/notebooks/guides/modules.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
     "# Modules\n",
@@ -229,7 +228,7 @@
     "`Branch` is the combination of a `Decision` and a *k*-way switch (a\n",
     "`switch`/`case` statement with *k* possible paths). It returns a\n",
     "tuple of *k* outputs, one slot per branch. At runtime, only the\n",
-    "branch picked by the classifier actually runs; the other *k* − 1\n",
+    "branch picked by the classifier actually runs; the other *k* \u2212 1\n",
     "slots come back as `None`.\n",
     "\n",
     "```python\n",
@@ -257,7 +256,7 @@
     "\n",
     "What happens, step by step:\n",
     "\n",
-    "1. The classifier picks an index `i` between 0 and *k* − 1.\n",
+    "1. The classifier picks an index `i` between 0 and *k* \u2212 1.\n",
     "2. Branch number `i` runs; the other branches skip and yield `None`.\n",
     "3. Code downstream must cope with `None` from the skipped branches.\n",
     "   The usual way to do that is the `Or` operator (`|`) you will meet\n",
@@ -440,6 +439,12 @@
     "    language_model=language_model,\n",
     ")(inputs)\n",
     "```\n",
+    "\n",
+    "By default the reward is a `synalinks.Score` (eleven values from 0.0 to\n",
+    "1.0). Pass `score_type=synalinks.Rating` (1 to 5), `Rating10`, `Rating20`\n",
+    "or `FineScore` to let the model grade on another scale: the module spells\n",
+    "the scale out in its default instructions and in the output schema, and\n",
+    "normalizes the picked value back to 0.0..1.0 before returning it.\n",
     "\n",
     "## Complete Example\n",
     "\n",
@@ -640,7 +645,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
    "source": [
     "## Setup\n",
@@ -649,9 +653,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
+   "execution_count": null,
    "outputs": [],
    "source": [
     "# @title Setup: run me first\n",
@@ -661,7 +664,6 @@
     "# then pull the models it needs. Slow on a CPU runtime; prefer a GPU one.\n",
     "!curl -fsSL https://ollama.com/install.sh | sh\n",
     "import subprocess, time\n",
-    "\n",
     "subprocess.Popen([\"ollama\", \"serve\"])\n",
     "time.sleep(5)\n",
     "!ollama pull mistral:latest"
@@ -669,9 +671,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
+   "execution_count": null,
    "outputs": [],
    "source": [
     "import asyncio\n",
@@ -902,20 +903,20 @@
     "\n",
     "\n",
     "if __name__ == \"__main__\":\n",
-    "    asyncio.run(main())"
+    "    asyncio.run(main())\n"
    ]
   }
  ],
  "metadata": {
-  "colab": {
-   "provenance": []
-  },
   "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"
   },
   "language_info": {
    "name": "python"
+  },
+  "colab": {
+   "provenance": []
   }
  },
  "nbformat": 4,

--- a/notebooks/guides/rewards.ipynb
+++ b/notebooks/guides/rewards.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
     "# Rewards\n",
@@ -19,7 +18,7 @@
     "\n",
     "A **reward** in Synalinks is a function\n",
     "\n",
-    "    r : (y_true, y_pred) → [0, 1]\n",
+    "    r : (y_true, y_pred) \u2192 [0, 1]\n",
     "\n",
     "where `y_true` is the known correct answer (a `DataModel`\n",
     "instance), `y_pred` is what the program produced (another\n",
@@ -181,6 +180,22 @@
     "returns a numeric score that the framework normalizes to\n",
     "`[0, 1]`.\n",
     "\n",
+    "By default the judge picks from `synalinks.Score` (eleven values\n",
+    "from 0.0 to 1.0). If your rubric reads more naturally as a\n",
+    "rating, pass `score_type=synalinks.Rating` (1 to 5), `Rating10`,\n",
+    "`Rating20` or `FineScore`:\n",
+    "\n",
+    "```python\n",
+    "reward = synalinks.rewards.LMAsJudge(\n",
+    "    language_model=judge_model,\n",
+    "    score_type=synalinks.Rating,\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "The judge's default instructions and output schema follow the\n",
+    "chosen scale, and the reward is still normalized to `[0, 1]`,\n",
+    "so optimizers and metrics see no difference.\n",
+    "\n",
     "Three things to know about LM judges:\n",
     "\n",
     "- **They are the most flexible reward.** You can grade things\n",
@@ -312,7 +327,7 @@
     "\n",
     "## Take-Home Summary\n",
     "\n",
-    "- A **reward** is a function `(y_true, y_pred) → [0, 1]`.\n",
+    "- A **reward** is a function `(y_true, y_pred) \u2192 [0, 1]`.\n",
     "  Higher is better. Non-differentiable is fine; we never\n",
     "  take its derivative.\n",
     "- **`in_mask` / `out_mask`** focus the reward on the\n",
@@ -343,7 +358,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
    "source": [
     "## Setup\n",
@@ -352,9 +366,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
+   "execution_count": null,
    "outputs": [],
    "source": [
     "# @title Setup: run me first\n",
@@ -364,7 +377,6 @@
     "# then pull the models it needs. Slow on a CPU runtime; prefer a GPU one.\n",
     "!curl -fsSL https://ollama.com/install.sh | sh\n",
     "import subprocess, time\n",
-    "\n",
     "subprocess.Popen([\"ollama\", \"serve\"])\n",
     "time.sleep(5)\n",
     "!ollama pull mistral:latest"
@@ -372,9 +384,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
+   "execution_count": null,
    "outputs": [],
    "source": [
     "import asyncio\n",
@@ -494,20 +505,20 @@
     "\n",
     "\n",
     "if __name__ == \"__main__\":\n",
-    "    asyncio.run(main())"
+    "    asyncio.run(main())\n"
    ]
   }
  ],
  "metadata": {
-  "colab": {
-   "provenance": []
-  },
   "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"
   },
   "language_info": {
    "name": "python"
+  },
+  "colab": {
+   "provenance": []
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Follow-up to #98: user-facing docs for the new score scales and the `score_type` argument, plus a fix for the broken source-snippet syntax across the docs.

- New API page **Data Models API → Score Data Models** rendering `synalinks.src.backend.pydantic.metrics`: `Score`, `FineScore`, `Rating`, `Rating10`, `Rating20`, plus `get_score_type` / `normalize_score`. Listed in the Data Models API index and the mkdocs nav.
- **Data Models guide** (guide 2): `Rating` row in the types table; a paragraph after the `Score` section introducing the sibling scales and `score_type`; summary bullet updated.
- **Modules guide** (guide 4): `SelfCritique` section explains the default `Score` reward and how `score_type` changes the scale (instructions + schema follow, value normalized to 0..1).
- **Rewards guide** (guide 13): `LMAsJudge` section gets a `score_type=synalinks.Rating` example and the normalization note.
- Source-snippet line anchors of the three edited guides recomputed; their Colab notebooks regenerated (`data_models`, `modules`, `rewards`). Other notebooks were left untouched even though the generator would reformat them (cell ids / unicode escaping drift vs. what's committed), to keep this PR to the docs change.
- **Snippet syntax fix (57 pages)**: the "Source" blocks used `--8 < --"path:N"`, which pymdownx snippets does not recognize, so the literal marker rendered instead of the code. Restored `--8<-- "path:N"` (and the `:source` section form) everywhere, and recomputed the three anchors that had gone stale (RLM agent, Deep Agent, Python Synthesis guides).

## Test plan

- [x] `uv run zensical build --clean` succeeds (with `check_paths: true`, so every snippet path resolves); the new page renders all scales/helpers and the three guide pages show the new text
- [x] Rendered guide/example pages now contain the expanded source code and no raw `--8<--` markers
- [x] Guides still parse and pass `ruff`
- [x] No em dashes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
