### PR TITLE
fix: cap glibc malloc arenas and trim the heap after each sandbox run

### DIFF
--- a/synalinks/src/sandboxes/mirage_sandbox.py
+++ b/synalinks/src/sandboxes/mirage_sandbox.py
@@ -28,6 +28,91 @@ from synalinks.src.sandboxes.sandbox import ExecutionResult
 from synalinks.src.sandboxes.sandbox import Sandbox
 from synalinks.src.saving.object_registration import register_synalinks_serializable
 
+# ---------------------------------------------------------------------------
+# Host heap hygiene.
+#
+# glibc's malloc gives every thread that allocates its own arena (a 64 MiB
+# heap mapping, up to 8 x cores of them) and never returns an arena's freed
+# memory to the OS. A sandbox host is exactly the process that suffers from
+# it: the asyncio default executor, the FUSE bridge, the tool-RPC loop and the
+# HTTP client all allocate from worker threads, and every ``run`` churns
+# multi-megabyte buffers through them (the dill-and-base64 ``inputs`` blob,
+# the persisted namespace, file contents crossing FUSE). After an hour of
+# snippets a host was measured at 2.2 GB resident with 14 MB of live Python
+# objects: 28 threads, 28 fully-resident 64 MiB arenas (``/proc/<pid>/smaps``,
+# 2026-08-30). Capping the arenas makes all threads share two, which bounds
+# the retained memory at a couple of hundred MB, and ``malloc_trim`` after each
+# run hands back what the shared arenas no longer use.
+#
+# Both are process-wide glibc settings and a no-op elsewhere (musl, macOS).
+# They are applied from the process itself so they also hold where no launcher
+# environment is available (a notebook kernel, a Kaggle submission); the
+# ``MALLOC_ARENA_MAX`` environment variable is the equivalent for a launcher.
+_M_ARENA_MAX = -8  # glibc <malloc.h>
+_malloc_arenas_capped: Optional[int] = None
+
+
+def _libc() -> Optional[Any]:
+    """The process's C library via ctypes, or ``None`` when it is not glibc."""
+    if not sys.platform.startswith("linux"):
+        return None
+    try:
+        import ctypes
+        import ctypes.util
+
+        libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6")
+        # ``mallopt``/``malloc_trim`` exist on glibc; musl has neither.
+        libc.mallopt
+        libc.malloc_trim
+        return libc
+    except (OSError, AttributeError):
+        return None
+
+
+def cap_malloc_arenas(max_arenas: int) -> bool:
+    """Cap glibc's per-thread malloc arenas for this process.
+
+    Idempotent: the first call wins for the life of the process, later calls
+    with the same or a higher cap are no-ops. Arenas that already exist keep
+    living; the cap governs the ones threads would create from now on, so call
+    it before the process starts its worker threads.
+
+    Args:
+        max_arenas (int): The ``M_ARENA_MAX`` value (``2`` is the usual choice
+            for a long-running service).
+
+    Returns:
+        bool: ``True`` when the cap is in place (now or from an earlier call),
+            ``False`` when the platform's allocator is not glibc.
+    """
+    global _malloc_arenas_capped
+    if _malloc_arenas_capped is not None and _malloc_arenas_capped <= max_arenas:
+        return True
+    libc = _libc()
+    if libc is None:
+        return False
+    if libc.mallopt(_M_ARENA_MAX, int(max_arenas)) != 1:
+        return False
+    _malloc_arenas_capped = int(max_arenas)
+    return True
+
+
+def malloc_trim() -> bool:
+    """Return freed heap pages to the OS (every glibc arena, not just the top).
+
+    Returns:
+        bool: ``True`` when memory was released, ``False`` when nothing could be
+            or the allocator is not glibc.
+    """
+    libc = _libc()
+    if libc is None:
+        return False
+    try:
+        return bool(libc.malloc_trim(0))
+    except Exception:  # noqa: BLE001 - never let hygiene break a run
+        return False
+
+
 # FUSE is optional to mirage: both of its mfusepy import sites fall back to
 # `fuse = None`, and the only consumer, FuseManager, is reached exclusively
 # through `Workspace.add_fuse_mount`. Nothing in MirageSandbox needs it except
@@ -2075,6 +2160,12 @@ class MirageSandbox(Sandbox):
             confined run, in MiB. ``None`` for no limit.
         cpu_limit_seconds (int): Optional. CPU-time cap (``RLIMIT_CPU``) for a
             confined run, in seconds. ``None`` for no limit.
+        malloc_arena_max (int): Optional. Cap on the host process's glibc
+            malloc arenas, applied once per process when the first sandbox is
+            built (``M_ARENA_MAX``; see ``cap_malloc_arenas``). Without it a
+            long-lived host retains a 64 MiB arena per worker thread that ever
+            allocated, gigabytes after hours of snippets. ``None`` leaves the
+            allocator alone. Defaults to ``2``.
         max_processes (int): Optional. Process cap (``RLIMIT_NPROC``) for a
             confined run (fork-bomb guard). Defaults to 64; ``None`` to disable.
             **Linux only.** ``RLIMIT_NPROC`` is counted per user, which on Linux
@@ -2125,6 +2216,10 @@ class MirageSandbox(Sandbox):
         "provided."
     )
 
+    # Class-level default so instances built without ``__init__`` (``load``,
+    # ``from_config``, forks) behave like a fresh sandbox.
+    _malloc_arena_max: Optional[int] = 2
+
     def __init__(
         self,
         timeout: float = 5.0,
@@ -2143,6 +2238,7 @@ class MirageSandbox(Sandbox):
         memory_limit_mb: Optional[int] = None,
         cpu_limit_seconds: Optional[int] = None,
         max_processes: Optional[int] = 64,
+        malloc_arena_max: Optional[int] = 2,
         extra_binds: Optional[List[str]] = None,
         workspace_kwargs: Optional[Dict[str, Any]] = None,
         external_functions: Optional[Dict[str, Callable]] = None,
@@ -2155,6 +2251,11 @@ class MirageSandbox(Sandbox):
         Sandbox.__init__(
             self, timeout=timeout, name=name, external_functions=external_functions
         )
+        # Before the FUSE mount and the tool-RPC thread below exist: a cap only
+        # governs arenas created after it.
+        if malloc_arena_max is not None:
+            cap_malloc_arenas(malloc_arena_max)
+        self._malloc_arena_max = malloc_arena_max
         self._session = session_id
         self._mode = mode if mode is not None else MountMode.EXEC
         self._workspace_kwargs = dict(workspace_kwargs or {})
@@ -2730,6 +2831,11 @@ class MirageSandbox(Sandbox):
                         pass
 
         stderr = _clean_traceback(stderr)
+        if self._malloc_arena_max is not None:
+            # The run's buffers (inputs blob, namespace, FUSE copies) are freed
+            # by now; give their pages back instead of keeping them in the
+            # arenas for the next hour.
+            malloc_trim()
         return self._record_run(
             code,
             ExecutionResult(

--- a/synalinks/src/sandboxes/mirage_sandbox_test.py
+++ b/synalinks/src/sandboxes/mirage_sandbox_test.py
@@ -10,7 +10,9 @@ from synalinks.src import testing
 from synalinks.src.sandboxes.mirage_sandbox import _MACOS_CONFINE_SRC
 from synalinks.src.sandboxes.mirage_sandbox import MirageSandbox
 from synalinks.src.sandboxes.mirage_sandbox import _confinement_available
+from synalinks.src.sandboxes.mirage_sandbox import cap_malloc_arenas
 from synalinks.src.sandboxes.mirage_sandbox import confinement_kind
+from synalinks.src.sandboxes.mirage_sandbox import malloc_trim
 from synalinks.src.sandboxes.sandbox import ExecutionResult
 from synalinks.src.sandboxes.sandbox import Sandbox
 
@@ -41,6 +43,92 @@ class _SandboxTestCase(testing.TestCase):
     def tearDown(self):
         super().tearDown()
         gc.collect()
+
+
+class MallocHygieneTest(_SandboxTestCase):
+    """The host-side glibc settings a sandbox applies to its own process."""
+
+    _GLIBC = sys.platform.startswith("linux") and "glibc" in (
+        getattr(__import__("platform"), "libc_ver", lambda: ("", ""))()[0] or ""
+    )
+
+    def test_cap_is_idempotent_and_reports_platform(self):
+        first = cap_malloc_arenas(2)
+        second = cap_malloc_arenas(2)
+        self.assertEqual(first, second)
+        if self._GLIBC:
+            self.assertTrue(first)
+
+    def test_trim_never_raises(self):
+        released = malloc_trim()
+        self.assertIsInstance(released, bool)
+        if not self._GLIBC:
+            self.assertFalse(released)
+
+    async def test_sandbox_caps_arenas_by_default_and_can_opt_out(self):
+        sandbox = MirageSandbox(timeout=_TIMEOUT)
+        self.assertEqual(sandbox._malloc_arena_max, 2)
+        untouched = MirageSandbox(timeout=_TIMEOUT, malloc_arena_max=None)
+        self.assertIsNone(untouched._malloc_arena_max)
+        result = await untouched.run("print('still runs')")
+        self.assertTrue(result.ok)
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux"), "glibc arenas are a Linux matter"
+    )
+    def test_cap_bounds_arena_mappings(self):
+        """Worker threads churning big buffers must not each keep a 64 MiB heap.
+
+        Runs in a child interpreter and counts how many 64 MiB-class anonymous
+        mappings (what a glibc arena looks like in ``/proc/self/maps``) the
+        churning threads add; imports create arenas of their own before the
+        cap, so only the growth is judged.
+        """
+        import subprocess
+
+        script = (
+            "import json, sys, threading\n"
+            "from synalinks.src.sandboxes.mirage_sandbox import cap_malloc_arenas\n"
+            "def arenas():\n"
+            "    n = 0\n"
+            "    for line in open('/proc/self/maps'):\n"
+            "        parts = line.split()\n"
+            "        if len(parts) != 5:\n"
+            "            continue\n"
+            "        lo, hi = (int(x, 16) for x in parts[0].split('-'))\n"
+            "        n += (60 << 20) <= hi - lo <= (70 << 20)\n"
+            "    return n\n"
+            "if sys.argv[1] == 'cap':\n"
+            "    assert cap_malloc_arenas(2)\n"
+            "before = arenas()\n"
+            "payload = {'rows': [list(range(4096)) for _ in range(300)]}\n"
+            "def churn():\n"
+            "    for _ in range(10):\n"
+            "        json.loads(json.dumps(payload))\n"
+            "threads = [threading.Thread(target=churn) for _ in range(24)]\n"
+            "[t.start() for t in threads]\n"
+            "[t.join() for t in threads]\n"
+            "print(arenas() - before)\n"
+        )
+
+        def arenas(mode):
+            out = subprocess.run(
+                [sys.executable, "-c", script, mode],
+                capture_output=True,
+                text=True,
+                timeout=120,
+                check=True,
+            )
+            return int(out.stdout.strip().splitlines()[-1])
+
+        if not self._GLIBC:
+            self.skipTest("not glibc")
+        # Only the capped bound is a guarantee. How many arenas the *default*
+        # allocator adds depends on how often the threads' mallocs overlap
+        # (the GIL serialises most Python-level churn; the FUSE bridge and
+        # ctypes calls that bloat a real host run outside it), so it is not
+        # asserted here.
+        self.assertLessEqual(arenas("cap"), 2)
 
 
 class MirageSandboxTest(_SandboxTestCase):


### PR DESCRIPTION
## The problem

A long-lived `MirageSandbox` host leaks resident memory that no Python object owns.

glibc's `malloc` gives every thread that allocates its own *arena* (a 64 MiB heap mapping, up to 8 × cores of them) and never returns an arena's freed memory to the OS. A sandbox host is exactly the process that suffers from it: the asyncio default executor, the FUSE bridge, the tool-RPC loop and the HTTP client all allocate from worker threads, and every `run` churns multi-megabyte buffers through them (the dill+base64 `inputs` blob, the persisted namespace, file contents crossing FUSE).

Measured on an RLM agent host (ARC-AGI-3, 4 games in parallel, 2-hour runs), with `tracemalloc` in the process and `/proc/<pid>/smaps` from outside:

| | |
|---|---|
| RSS after ~1 h of snippets | **2.2 GB** |
| live Python objects (tracemalloc) | 14 MB |
| observer store | 5.6 MB |
| threads | 28 |
| fully-resident 64 MiB anonymous mappings | **28** (1.8 GB) |
| main heap | 737 MB |

The heaviest game was killed by a 3 GB watchdog after 42 minutes. Anyone running an RLM + sandbox for hours on Linux gets the same curve; short demos never show it. The 25-game sweep that OOM'd a 16 GB machine was most likely this, not the runaway snippet it was blamed on.

## The fix

- `cap_malloc_arenas(n)` — `mallopt(M_ARENA_MAX, n)` once per process. glibc only (no-op on musl/macOS), idempotent.
- `malloc_trim()` — releases freed pages from every arena, not just the top of the main heap.
- `MirageSandbox(malloc_arena_max=2)` — caps the arenas when the first sandbox is built, before its FUSE mount and RPC thread exist (a cap only governs arenas created after it), and trims after each `run`. `malloc_arena_max=None` opts out.

It is applied from the process itself rather than through `MALLOC_ARENA_MAX` so it also holds where no launcher environment is available: notebook kernels, Kaggle submissions. Functionally nothing changes for callers — threads draw from two shared arenas instead of private ones; the only cost is allocator lock contention, negligible in a host whose threads are I/O-bound.

## Not in this PR

The cap bounds the damage; the churn that causes it is a separate item: the `inputs` blob is re-dilled and re-encoded on every `run` even when unchanged, and file contents cross FUSE through Python `bytes` on worker threads. Caching the blob per unchanged inputs would remove most of the per-run allocation.

## Tests

`MallocHygieneTest`: idempotence, trim never raises, default/opt-out on the sandbox, and a child-interpreter check that 24 churning threads add at most 2 arenas under the cap (only the capped bound is asserted — how many arenas the default allocator adds depends on how often the threads' mallocs overlap, which the GIL makes unreliable in a synthetic test).

`mirage_sandbox_test.py`: 128 passed, 9 skipped. `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144Z7kEoHuK8Fkpj3fMiamR
