### PR TITLE
fix: stop rebuilding the Ladybug FTS index on every write (native memory leak)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "inquirer",
   "jinja2",
   "jsonschema",
-  "ladybug>=0.17.1",
+  "ladybug>=0.19.1",
   "lancedb>=0.30.2",
   "litellm>=1.84.0",
   "markdown-it-py",

--- a/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter.py
+++ b/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter.py
@@ -578,13 +578,14 @@ class LadybugAdapter(GraphDatabaseAdapter):
         existing_node = self._existing_tables("NODE")
         existing_rel = self._existing_tables("REL")
 
-        # Per-label record of which columns the FTS index covers, so
-        # ``_rebuild_fts_index`` (called after every ``update_entities``
-        # batch) can drop + recreate the index against the same
-        # columns. Ladybug's FTS index is a snapshot built at
-        # CREATE_FTS_INDEX time, so it must be rebuilt after inserts,
-        # same pattern DuckDB uses with PRAGMA create_fts_index +
-        # overwrite=1 at the end of every ``update``.
+        # Per-label record of which columns the FTS index covers, so a
+        # label's index can be recreated against the same columns when a
+        # table is rebuilt (``_rebuild_fts_index``). Ladybug maintains the
+        # index on insert / update / delete itself, so the write paths never
+        # rebuild it: a drop + create per write is not only redundant, on an
+        # in-memory database the dropped index is never released and a
+        # write-heavy caller leaks its size on every batch (measured at
+        # 19 MB per batch of a few KB of text, 2026-08-30).
         self._fts_columns: Dict[str, List[str]] = {}
 
         # Per-label record of the primary-key column name. ``label`` is
@@ -714,11 +715,9 @@ class LadybugAdapter(GraphDatabaseAdapter):
     def _create_fts_index(self, label: str, columns: List[str]) -> None:
         """Build the FTS index for a label over the given columns.
 
-        Ladybug's FTS index is a snapshot of the table at creation
-        time: inserts after this point don't show up until the
-        index is rebuilt. `update_entities` triggers that
-        rebuild via `_rebuild_fts_index` at write time, so
-        search paths assume the index is current.
+        Ladybug keeps the index current on insert / update / delete, so
+        this runs once per label (at schema setup or on first sight of a
+        free-form label) and the search paths can assume it is current.
 
         Optional build params (``stemmer`` / ``stopwords`` /
         ``tokenizer``) come from the matching ``self.<name>``
@@ -766,9 +765,10 @@ class LadybugAdapter(GraphDatabaseAdapter):
     def _rebuild_fts_index(self, label: str) -> None:
         """Drop and recreate the FTS index for a label.
 
-        Called from the write paths (`update_entities`) after the
-        underlying inserts have committed. Search paths assume the
-        index is current: they never rebuild at query time.
+        Not part of the write path: Ladybug maintains the index itself,
+        and on an in-memory database a dropped index is never released.
+        Kept for the cases where the table underneath changed shape (a
+        label migration) and the index has to be declared afresh.
         """
         if label not in self._fts_columns:
             return
@@ -1301,22 +1301,7 @@ class LadybugAdapter(GraphDatabaseAdapter):
             return None if scalar_in else []
 
         ids = [await self._upsert_entity(e) for e in items]
-
-        # FTS index rebuild is best-effort; data is already committed.
-        # Same shape as the DuckDB adapter: pay the rebuild cost on
-        # the write path so search paths can stay query-only.
-        touched_labels = {sanitize_label(entity.get("label")) for entity in items}
-        for label in touched_labels:
-            if label not in self._fts_columns:
-                continue
-            try:
-                self._rebuild_fts_index(label)
-            except Exception as e:  # noqa: BLE001
-                warnings.warn(
-                    f"FTS index rebuild failed for {label!r}; "
-                    f"entity_fulltext_search results may be stale. ({e})"
-                )
-
+        # No FTS rebuild here: Ladybug updates the index with the rows.
         return ids[0] if scalar_in else ids
 
     async def _upsert_entity(self, entity: Any) -> Optional[Any]:
@@ -1879,17 +1864,8 @@ class LadybugAdapter(GraphDatabaseAdapter):
             {"ids": ids},
         ) as r:
             deleted = len(r.get_all())
-
-        # Best-effort FTS rebuild; failure here just means searches
-        # may report stale hits until the next write triggers a rebuild.
-        if label in self._fts_columns:
-            try:
-                self._rebuild_fts_index(label)
-            except Exception as e:  # noqa: BLE001
-                warnings.warn(
-                    f"FTS index rebuild failed for {label!r} after delete; "
-                    f"entity_fulltext_search results may be stale. ({e})"
-                )
+        # No FTS rebuild here either: the delete drops the rows from the
+        # index as well.
         return deleted
 
     async def delete_relation(

--- a/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter_test.py
+++ b/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter_test.py
@@ -7,6 +7,8 @@ with a deterministic stub (no LLM calls) so dedup behaviour is
 verifiable.
 """
 
+import sys
+import unittest
 from typing import List
 from typing import Literal
 from unittest.mock import patch
@@ -476,6 +478,87 @@ class LadybugAdapterTest(testing.TestCase):
         with patch.object(adapter, "_rebuild_fts_index", _explode):
             results = await adapter.entity_fulltext_search("Alice", label="Person")
         self.assertEqual(len(results), 1)
+
+    async def test_write_paths_never_rebuild_fts(self):
+        """Ladybug maintains the FTS index on insert / update / delete, so
+        neither update_entities nor delete_entity may drop + recreate it:
+        on an in-memory database a dropped index is never released, and a
+        write-heavy caller leaked its size on every batch. Search must
+        still see every write without a rebuild."""
+        adapter = self._adapter(embedding_model=_StubEmbeddingModel({}))
+
+        def _explode(*a, **kw):
+            raise AssertionError("_rebuild_fts_index must not run on a write path")
+
+        with patch.object(adapter, "_rebuild_fts_index", _explode):
+            await adapter.update_entities(
+                Person(label="Person", name="Alice", embedding=[1.0, 0.0, 0.0])
+            )
+            await adapter.update_entities(
+                [
+                    Person(label="Person", name="Bob", embedding=[0.0, 1.0, 0.0]),
+                    Person(label="Person", name="Carol", embedding=[0.0, 0.0, 1.0]),
+                ]
+            )
+            self.assertEqual(
+                [
+                    r["name"]
+                    for r in await adapter.entity_fulltext_search("Bob", label="Person")
+                ],
+                ["Bob"],
+            )
+            await adapter.delete_entity("Bob", label="Person")
+            self.assertEqual(
+                await adapter.entity_fulltext_search("Bob", label="Person"), []
+            )
+            self.assertEqual(
+                len(await adapter.entity_fulltext_search("Carol", label="Person")), 1
+            )
+
+    @unittest.skipUnless(sys.platform.startswith("linux"), "mallinfo2 is glibc")
+    async def test_repeated_writes_do_not_grow_native_memory(self):
+        """The leak was native (Ladybug's C++ heap), invisible to tracemalloc:
+        judge it by glibc's own in-use byte count. With the per-write rebuild
+        50 batches cost ~1 GB; without it they cost a few MB."""
+        import ctypes
+        import ctypes.util
+
+        libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6")
+
+        class MallInfo2(ctypes.Structure):
+            _fields_ = [
+                (n, ctypes.c_size_t)
+                for n in (
+                    "arena",
+                    "ordblks",
+                    "smblks",
+                    "hblks",
+                    "hblkhd",
+                    "usmblks",
+                    "fsmblks",
+                    "uordblks",
+                    "fordblks",
+                    "keepcost",
+                )
+            ]
+
+        libc.mallinfo2.restype = MallInfo2
+        adapter = self._adapter(embedding_model=_StubEmbeddingModel({}))
+        await adapter.update_entities(
+            Person(label="Person", name="warmup", embedding=[1.0, 0.0, 0.0])
+        )
+        before = libc.mallinfo2().uordblks
+        for i in range(50):
+            await adapter.update_entities(
+                [
+                    Person(label="Person", name=f"p{i}-{j}", embedding=[1.0, 0.0, 0.0])
+                    for j in range(3)
+                ]
+            )
+        grown_mb = (libc.mallinfo2().uordblks - before) / 1e6
+        self.assertLess(
+            grown_mb, 100, f"native heap grew {grown_mb:.0f} MB over 50 batches"
+        )
 
     async def test_creating_an_existing_fts_index_is_silent(self):
         """Reopening a persistent store re-declares its entity models, so


### PR DESCRIPTION
## The problem

Every `update_entities` and `delete_entity` on the Ladybug adapter ended with `_rebuild_fts_index`: `CALL DROP_FTS_INDEX` + `CALL CREATE_FTS_INDEX` for the label. Two things are wrong with that:

1. **The premise is stale.** The code assumes Ladybug's FTS index is a snapshot taken at creation. On 0.19.1 the engine maintains it: rows inserted, updated and deleted after `CREATE_FTS_INDEX` are all reflected by `QUERY_FTS_INDEX` with no rebuild (verified directly against the engine; the new test pins it).
2. **On an in-memory database a dropped index is never released.** So every write batch leaked the whole index in native (C++) memory — invisible to `tracemalloc`, which is why it took `/proc/<pid>/smaps` + `mallinfo2` to find.

Measured on a write-heavy caller (an RLM agent that stores its primitive library on every snippet, `KnowledgeBase(graph_uri="ladybug://:memory:")`):

| | per write batch | 100 batches |
|---|---|---|
| with the rebuild | **+38 MB** glibc in-use | 4.5 GB (killed by the memory watchdog) |
| without | +0.9 MB | ~90 MB |

In the real agent that was 2–3 GB per process after two hours, 4 processes on a 16 GB box. Bisected by operation (`update_entities` leaks; `cypher`, `get_entity`, regex search are flat) and confirmed by monkeypatching `_rebuild_fts_index` to a no-op.

## The fix

- `update_entities` / `delete_entity` no longer touch the index.
- `_rebuild_fts_index` stays (table migrations still need to declare an index afresh); its docstring and the schema-setup comment now say why it is not a write-path operation.
- `ladybug>=0.19.1` — the version the engine-maintained index was verified on. If you know it holds on 0.17, feel free to relax it.

The DuckDB adapter's `PRAGMA create_fts_index(... overwrite=1)` per write is the same shape; DuckDB's FTS *is* a snapshot so it's correct there, and not touched here.

## Tests

- `test_write_paths_never_rebuild_fts`: `_rebuild_fts_index` patched to raise; three inserts and a delete; full-text search sees the new rows and not the deleted one.
- `test_repeated_writes_do_not_grow_native_memory` (Linux): 50 write batches grow glibc's `mallinfo2().uordblks` by < 100 MB (was ~1 GB).
- `test_update_entities_rebuilds_fts_at_write_time` still passes as written (search after a write is current, no rebuild in the search path) — its docstring is now slightly misnamed; happy to rename it if you prefer.

`ladybug_adapter_test.py`: 180 passed. `ruff check` / `ruff format --check` clean.

Related: #102 (glibc arena cap) is the mitigation I wrote before finding this; it still helps (28 → 11 resident arenas on the same host) but this PR is the actual leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144Z7kEoHuK8Fkpj3fMiamR
