### PR TITLE
fix: pin `inputs` in the sandbox so a snippet assigning over it breaks only itself

### DIFF
--- a/synalinks/src/modules/agents/rlm_agent.py
+++ b/synalinks/src/modules/agents/rlm_agent.py
@@ -1432,9 +1432,13 @@ class RecursiveLanguageModelAgent(FunctionCallingAgent):
         sandbox.bind_functions(external_functions)
         # Persist the full input payload as `inputs` in the sandbox namespace.
         # The per-run `inputs=` binding does not persist, so copy it into a real
-        # variable once; every snippet then reads it via `inputs[field]`.
+        # variable once; every snippet then reads it via `inputs[field]`. The
+        # name is also PINNED (``__rlm_pinned__``): the sandbox re-asserts it at
+        # the start of every run, so a snippet that assigns over ``inputs`` —
+        # LLM-written code does — breaks only itself, not the rest of the call.
         bind = await sandbox.run(
-            "inputs = _rlm_inputs", inputs={"_rlm_inputs": inputs_json}
+            "inputs = _rlm_inputs\n__rlm_pinned__ = {'inputs': _rlm_inputs}",
+            inputs={"_rlm_inputs": inputs_json},
         )
         if not bind.ok:
             raise RuntimeError(

--- a/synalinks/src/sandboxes/mirage_sandbox.py
+++ b/synalinks/src/sandboxes/mirage_sandbox.py
@@ -650,6 +650,17 @@ if os.path.exists(state):
             ns.update(dill.load(fh))
     except Exception as exc:
         print("restore-warn: " + repr(exc), file=sys.stderr)
+# Pinned names re-assert themselves on every run, from the persisted
+# ``__rlm_pinned__`` dict, BEFORE the per-run ``inputs=`` binding (so an
+# explicit binding still wins). A caller that persists an environment
+# variable for the agent's code to read (the RLM binds the module input as
+# ``inputs`` once per call) pins it so that a snippet assigning over the
+# name — LLM-written code does — only breaks that one snippet, instead of
+# poisoning every later snippet of the call: the next run restores the pin.
+try:
+    ns.update(ns.get("__rlm_pinned__") or {})
+except Exception as exc:
+    print("pinned-warn: " + repr(exc), file=sys.stderr)
 _inputs = config.get("inputs")
 if _inputs:
     try:

--- a/synalinks/src/sandboxes/mirage_sandbox_test.py
+++ b/synalinks/src/sandboxes/mirage_sandbox_test.py
@@ -43,6 +43,65 @@ class _SandboxTestCase(testing.TestCase):
         gc.collect()
 
 
+class PinnedNamesTest(_SandboxTestCase):
+    """``__rlm_pinned__`` re-asserts environment names on every run.
+
+    The RLM binds its module input as ``inputs`` once per call; before the
+    pin, a snippet assigning over the name (LLM-written code does) poisoned
+    every later snippet of the call — ``inputs`` stayed ``None`` and every
+    function reading it kept failing until the next call re-bound it."""
+
+    async def test_pinned_name_heals_on_the_next_run(self):
+        sandbox = MirageSandbox(timeout=_TIMEOUT)
+        await sandbox.run(
+            "inputs = _rlm_inputs\n__rlm_pinned__ = {'inputs': _rlm_inputs}",
+            inputs={"_rlm_inputs": {"frames": [1, 2, 3]}},
+        )
+        # The clobbering snippet breaks itself...
+        broken = await sandbox.run("inputs = None\nprint(inputs['frames'])")
+        self.assertIsNotNone(broken.error)
+        # ...and only itself: the next run reads the pinned value again.
+        healed = await sandbox.run("print(inputs['frames'])")
+        self.assertTrue(healed.ok, healed.error)
+        self.assertIn("[1, 2, 3]", healed.stdout)
+
+    async def test_functions_reading_the_pinned_name_recover_too(self):
+        sandbox = MirageSandbox(timeout=_TIMEOUT)
+        await sandbox.run(
+            "inputs = _rlm_inputs\n__rlm_pinned__ = {'inputs': _rlm_inputs}",
+            inputs={"_rlm_inputs": {"frames": [7]}},
+        )
+        await sandbox.run("def first_frame():\n    return inputs['frames'][0]")
+        await sandbox.run("inputs = 'garbage'")
+        result = await sandbox.run("print(first_frame())")
+        self.assertTrue(result.ok, result.error)
+        self.assertIn("7", result.stdout)
+
+    async def test_per_run_binding_still_wins_over_the_pin(self):
+        sandbox = MirageSandbox(timeout=_TIMEOUT)
+        await sandbox.run(
+            "inputs = _rlm_inputs\n__rlm_pinned__ = {'inputs': _rlm_inputs}",
+            inputs={"_rlm_inputs": {"frames": ["old"]}},
+        )
+        result = await sandbox.run(
+            "print(inputs['frames'])", inputs={"inputs": {"frames": ["fresh"]}}
+        )
+        self.assertTrue(result.ok, result.error)
+        self.assertIn("fresh", result.stdout)
+
+    async def test_rebinding_the_pin_replaces_it(self):
+        sandbox = MirageSandbox(timeout=_TIMEOUT)
+        for payload in ({"n": 1}, {"n": 2}):
+            await sandbox.run(
+                "inputs = _rlm_inputs\n__rlm_pinned__ = {'inputs': _rlm_inputs}",
+                inputs={"_rlm_inputs": payload},
+            )
+        await sandbox.run("inputs = None")
+        result = await sandbox.run("print(inputs['n'])")
+        self.assertTrue(result.ok, result.error)
+        self.assertIn("2", result.stdout)
+
+
 class MirageSandboxTest(_SandboxTestCase):
     async def test_is_sandbox_subclass(self):
         sandbox = MirageSandbox(timeout=_TIMEOUT)


### PR DESCRIPTION
## The problem

`RLM._begin_call` persists the module input as a sandbox variable once per call (`inputs = _rlm_inputs`) — the per-run `inputs=` binding doesn't persist, so this was the way every snippet could read `inputs[field]`. But the name is an ordinary global: when an LLM-written snippet assigns over it (`inputs = None`, `inputs = inputs["frames"]`, …), **every later snippet of that call is poisoned**, including sandbox functions that read `inputs` internally. Nothing re-binds until the next module call.

Observed in an ARC-AGI-3 agent (frames bound as `inputs`, `plan`/`verify_world_model` read `inputs["frames"]`): one bad snippet mid-investigation broke the rest of the turn; the agent's memory ledger records it submitting a no-op probe purely to end the turn and get `inputs` back. Its transcripts show workaround attempts (`inputs = ns['inputs']`) from earlier encounters with the same trap.

## The fix

A tiny pinning mechanism, no per-snippet re-encoding of the payload (the blob is multi-MB; re-binding it on every run is exactly the churn we don't want):

- **Bootstrap**: at the start of every run, re-assert the names in the persisted `__rlm_pinned__` dict — after the state restore, before the per-run `inputs=` binding, so an explicit binding still wins.
- **RLM**: pins `inputs` when it binds it (`__rlm_pinned__ = {'inputs': _rlm_inputs}`).

A clobbering snippet still sees its own assignment (normal Python shadowing within the run), but the next run heals. Re-binding on the next module call replaces the pin.

## Tests

`PinnedNamesTest`: heal on the next run; functions reading the pinned name recover; a per-run `inputs=` binding beats the pin; re-binding replaces the pin. Full `mirage_sandbox_test.py` + `rlm_agent_test.py`: 167 passed, 9 skipped. ruff clean.

Related: #102, #103 (same investigation — the host memory work on the same agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144Z7kEoHuK8Fkpj3fMiamR
