### PR TITLE
reasoning_effort accepts 'xhigh'

### DIFF
--- a/synalinks/src/backend/pydantic/chat_completions.py
+++ b/synalinks/src/backend/pydantic/chat_completions.py
@@ -313,9 +313,11 @@ class ChatCompletionRequest(DataModel):
         description="End-user identifier for abuse monitoring",
         default=None,
     )
-    reasoning_effort: Optional[Literal["minimal", "low", "medium", "high"]] = Field(
-        description="Reasoning effort hint for reasoning-capable models",
-        default=None,
+    reasoning_effort: Optional[Literal["minimal", "low", "medium", "high", "xhigh"]] = (
+        Field(
+            description="Reasoning effort hint for reasoning-capable models",
+            default=None,
+        )
     )
     parallel_tool_calls: Optional[bool] = Field(
         description="Whether to allow the model to call multiple tools in parallel",

--- a/synalinks/src/modules/agents/rlm_agent.py
+++ b/synalinks/src/modules/agents/rlm_agent.py
@@ -775,7 +775,7 @@ class RecursiveLanguageModelAgent(FunctionCallingAgent):
             the generator prompt (Default False).
         use_outputs_schema (bool): Optional. Feed the output schema to
             the generator prompt (Default False).
-        reasoning_effort (str): Optional. One of ``'minimal'``,
+        reasoning_effort (str): Optional. One of ``'xhigh'``, ``'minimal'``,
             ``'low'``, ``'medium'``, ``'high'``, ``'disable'``,
             ``'none'``, ``None``. Default ``None``.
         use_chain_of_thought (bool): Optional. Wrap the per-turn

--- a/synalinks/src/modules/core/generator.py
+++ b/synalinks/src/modules/core/generator.py
@@ -263,7 +263,7 @@ class Generator(Module):
         self.max_tokens = max_tokens
         self.top_p = top_p
         self.top_k = top_k
-        efforts = ["minimal", "low", "medium", "high", "disable", "none", None]
+        efforts = ["minimal", "low", "medium", "high", "xhigh", "disable", "none", None]
         if reasoning_effort not in efforts:
             raise ValueError(
                 f"The reasoning effort parameter should be one of: {efforts}"

--- a/synalinks/src/modules/ttc/chain_of_thought.py
+++ b/synalinks/src/modules/ttc/chain_of_thought.py
@@ -95,7 +95,7 @@ class ChainOfThought(Module):
         top_k (int): Optional. The top-k sampling cutoff for the LM call.
             Default None (the model's own default).
         reasoning_effort (string): Optional. The reasoning effort for the LM call
-            between ['minimal', 'low', 'medium', 'high', 'disable', 'none'].
+            between ['minimal', 'low', 'medium', 'high', 'xhigh', 'disable', 'none'].
             (Default to 'low'). If reasoning effort is none or disabled, a thinking
             field is automatically added to the output data model. Otherwise,
             the thinking field is automatically populated by the model's

--- a/synalinks/src/modules/ttc/self_critique.py
+++ b/synalinks/src/modules/ttc/self_critique.py
@@ -211,7 +211,8 @@ class SelfCritique(Module):
         top_k (int): Optional. The top-k sampling cutoff for the LM call.
             Default None (the model's own default).
         reasoning_effort (string): Optional. The reasoning effort for the LM call
-            between ['minimal', 'low', 'medium', 'high', 'disable', 'none', None].
+            between ['minimal', 'low', 'medium', 'high', 'xhigh', 'disable',
+            'none', None].
             Default to None (no reasoning).
         use_inputs_schema (bool): Optional. Whether or not use the inputs schema in
             the prompt (Default to False) (see `Generator`).

--- a/synalinks/src/optimizers/omega.py
+++ b/synalinks/src/optimizers/omega.py
@@ -287,7 +287,8 @@ class OMEGA(EvolutionaryOptimizer):
         crossover_temperature (float): The temperature for the LM calls of
             the crossover programs.
         reasoning_effort (string): Optional. The reasoning effort for the LM call
-            between ['minimal', 'low', 'medium', 'high', 'disable', 'none', None].
+            between ['minimal', 'low', 'medium', 'high', 'xhigh', 'disable',
+            'none', None].
             Default to None (no reasoning).
         use_chain_of_thought (bool): Whether the mutation/crossover programs use
             a `ChainOfThought` (which first writes a prompt-driven `thinking`


### PR DESCRIPTION
`ChatCompletionRequest.reasoning_effort` was `Literal["minimal", "low", "medium", "high"]`, but reasoning backends have moved past that set: the vLLM OpenAI server for Qwen3.8 accepts exactly `low` / `medium` / `xhigh` — `xhigh` is its **default** — and rejects `high` and `minimal` with a 400. So the one effort that stack runs by default was unreachable through synalinks, while two values the schema allows are hard errors there.

This adds `"xhigh"` to the Literal (and mentions it in the RLM docstring). Validation of which values a given backend actually supports stays where it belongs — the server — since the supported set is model- and server-dependent.

Found while sweeping reasoning efforts on an ARC-AGI-3 RLM agent (same investigation as #102/#103/#104).

`chat_completions` tests and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144Z7kEoHuK8Fkpj3fMiamR
