### PR TITLE
fix(ladybug): reconnect after wipe_database so a re-created label is writable

### DIFF
--- a/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter.py
+++ b/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter.py
@@ -1039,6 +1039,20 @@ class LadybugAdapter(GraphDatabaseAdapter):
         TABLE`` while an FTS or vector index references it. So the
         order is: every FTS / vector index, then every REL table (FK
         to nodes), then the NODE tables themselves.
+
+        Then the connection is replaced. Ladybug keeps per-connection
+        catalog state, and once a table has been dropped and re-created
+        under the same name the *old* connection's next write to it
+        fails (``Cannot find table catalog entry with id N``) or, when an
+        FTS index was rebuilt on the new table, segfaults. That is
+        reproducible with the raw driver, and a wipe is exactly the
+        drop-and-recreate case: every label the adapter sees again is a
+        re-created table. A fresh ``Connection`` on the same ``Database``
+        starts clean and keeps the loaded extensions.
+
+        The per-label registries are cleared for the same reason: they
+        would still describe the dropped tables, and ``_ensure_node_table``
+        trusts them to skip creation.
         """
         for table, name, idx_type in self._existing_indices():
             try:
@@ -1061,6 +1075,12 @@ class LadybugAdapter(GraphDatabaseAdapter):
                     self._con.execute(f"DROP TABLE {name}")
                 except Exception as e:  # noqa: BLE001
                     warnings.warn(f"Failed to drop table {name!r}: {e}")
+
+        self.close()
+        self._con = lb.Connection(self._db)
+        # Absent when called from the constructor, before `_setup_schema`.
+        for registry in ("_pk_keys", "_fts_columns", "_synth_models"):
+            getattr(self, registry, {}).clear()
 
     def _existing_indices(self) -> List[tuple]:
         """Return ``[(table_name, index_name, index_type), ...]``."""

--- a/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter_test.py
+++ b/synalinks/src/knowledge_bases/graph_database_adapters/ladybug_adapter_test.py
@@ -599,6 +599,29 @@ class LadybugAdapterTest(testing.TestCase):
         self.assertEqual(adapter._existing_tables("NODE"), set())
         self.assertEqual(adapter._existing_tables("REL"), set())
 
+    async def test_wipe_database_leaves_a_writable_store(self):
+        """A wiped store must take the same label again, on the same adapter.
+
+        Ladybug keeps per-connection catalog state: after a table is dropped
+        and re-created under the same name, the next write to it through the
+        old connection fails ("Cannot find table catalog entry") or segfaults
+        when an FTS index was rebuilt on it. Reproducible with the raw driver.
+        `wipe_database` is the one place the adapter drops tables it will
+        create again, so it has to hand back a connection that can."""
+        adapter = self._adapter()
+        await adapter.update_entities(Person(label="Person", name="Alice"))
+        for name in ("Bob", "Carol"):
+            adapter.wipe_database()
+            self.assertEqual(adapter._existing_tables("NODE"), set())
+            # The label is re-created lazily from the entity, so the registry
+            # must have forgotten the dropped table too.
+            self.assertNotIn("Person", adapter._pk_keys)
+            await adapter.update_entities(Person(label="Person", name=name))
+            rows = adapter._con.execute(
+                "MATCH (p:Person) RETURN p.name AS name"
+            ).get_all()
+            self.assertEqual(rows, [[name]])
+
     async def test_cypher_binds_parameters_safely(self):
         """`$`-parameters bind values, not SQL/Cypher syntax: strings
         containing apostrophes or quotes must round-trip intact."""


### PR DESCRIPTION
## Problem

`LadybugAdapter.wipe_database()` drops every table, but keeps using the same `Connection`. Ladybug keeps per-connection catalog state, so once a table is dropped and re-created under the same name, the old connection's next write to it fails — or segfaults when an FTS index was rebuilt on the new table. Every label the adapter sees after a wipe *is* a re-created table, so:

```python
adapter = LadybugAdapter(uri="ladybug://:memory:", entity_models=[Person])
await adapter.update_entities(Person(label="Person", name="Alice"))
adapter.wipe_database()
await adapter.update_entities(Person(label="Person", name="Bob"))   # crash
```

Reproducible with the raw driver, no adapter involved (0.19.1 → `Table with ID 0 not found in any attached database`; 0.20.2 → `Cannot find table catalog entry with id 1`, and a hard segfault once `CREATE_FTS_INDEX` is called on the re-created table):

```python
con.execute("CREATE NODE TABLE Topic(name STRING, PRIMARY KEY(name))")
con.execute("CALL CREATE_FTS_INDEX('Topic', 'topic_fts', ['name'])")
con.execute("MERGE (n:Topic {name: 'one'})")
con.execute("CALL DROP_FTS_INDEX('Topic', 'topic_fts')")
con.execute("DROP TABLE Topic")
con.execute("CREATE NODE TABLE Topic(name STRING, PRIMARY KEY(name))")
con.execute("CALL CREATE_FTS_INDEX('Topic', 'topic_fts', ['name'])")
con.execute("MERGE (n:Topic {name: 'two'})")   # segfault
```

A fresh `lb.Connection` on the same `lb.Database` is clean, and keeps the loaded extensions.

## Fix

`wipe_database` now replaces the connection after dropping the tables, and clears the per-label registries (`_pk_keys`, `_fts_columns`, `_synth_models`), which would otherwise still describe the dropped tables and make `_ensure_node_table` skip creation. The constructor's `wipe_on_start` path goes through the same method and still runs `_setup_schema` afterwards.

## Test

`test_wipe_database_leaves_a_writable_store`: insert → wipe → insert the same label, twice. Fails on `main` (stale registry, then the write), passes with the fix. Full `graph_database_adapters/` and `knowledge_bases/` suites pass.
