### PR TITLE
fix: read structured output from tool_calls for every tool-call provider (openrouter, cohere, bedrock)

### DIFF
--- a/synalinks/src/modules/language_models/language_model.py
+++ b/synalinks/src/modules/language_models/language_model.py
@@ -809,7 +809,11 @@ class LanguageModel(Module):
                 # don't support native JSON schema (cohere, most bedrock
                 # models) or proxy heterogeneous backends with mixed
                 # support (openrouter), so tool-call structured output
-                # is the most reliable path.
+                # is the most reliable path. The tool's `parameters` is a
+                # JSON Schema object, so the whole schema goes in (its
+                # `type`, `required` and `additionalProperties` included),
+                # not just the property map. The reply then carries the
+                # JSON as the call's `arguments`; see `_do_call`.
                 kwargs.update(
                     {
                         "tools": [
@@ -817,7 +821,7 @@ class LanguageModel(Module):
                                 "function": {
                                     "name": "structured_output",
                                     "description": "Generate a valid JSON output",
-                                    "parameters": schema.get("properties"),
+                                    "parameters": schema,
                                 },
                                 "type": "function",
                             }
@@ -1092,11 +1096,24 @@ class LanguageModel(Module):
                 audio = _safe_get(response_message, "audio")
                 if audio is not None and hasattr(audio, "model_dump"):
                     audio = audio.model_dump()
-                if self.model.startswith("groq") and schema:
-                    # Groq uses tool_calls for structured output
-                    response_str = response_message["tool_calls"][0]["function"][
-                        "arguments"
-                    ]
+                if schema and wire_tool_calls:
+                    # Structured output requested as a forced tool call
+                    # (groq, cohere, openrouter, bedrock): the JSON is the
+                    # call's `arguments`, while `content` is empty or a
+                    # short preamble. Read it wherever a tool call came
+                    # back, whatever the provider, so the request and the
+                    # parse never disagree on where the JSON lives.
+                    arguments = _safe_get(
+                        _safe_get(wire_tool_calls[0], "function"), "arguments", ""
+                    )
+                    if isinstance(arguments, (dict, list)):
+                        arguments = orjson.dumps(arguments).decode()
+                    response_str = arguments.strip() if arguments else ""
+                    if not response_str:
+                        raise ValueError(
+                            "The language model returned a structured_output tool "
+                            "call without arguments."
+                        )
                 else:
                     # Anthropic and other providers use response_format,
                     # which returns content in message["content"]

--- a/synalinks/src/modules/language_models/language_model_test.py
+++ b/synalinks/src/modules/language_models/language_model_test.py
@@ -1,7 +1,6 @@
 # License Apache 2.0: (c) 2025-2026 Yoan Sallami (Synalinks Team)
 
 import base64
-import copy
 import os
 import warnings
 from unittest.mock import patch
@@ -103,6 +102,92 @@ class LanguageModelTest(testing.TestCase):
             result.get_json(), AnswerWithRationale(**result.get_json()).get_json()
         )
         self.assertEqual(result.get_json(), expected.get_json())
+
+    @patch("litellm.acompletion")
+    async def test_structured_output_via_tool_call_reads_the_arguments(
+        self, mock_completion
+    ):
+        # openrouter (like groq, cohere, bedrock) is asked for structured
+        # output as a forced `structured_output` tool call, so the JSON comes
+        # back as the call's arguments and `content` is empty. It used to be
+        # read from `content`, fail to parse, and score every row as None.
+        language_model = LanguageModel(model="openrouter/anthropic/claude-opus-4.1")
+
+        class Answer(DataModel):
+            answer: str
+
+        mock_completion.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "structured_output",
+                                    "arguments": '{"answer": "B"}',
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+
+        messages = ChatMessages(
+            messages=[ChatMessage(role=ChatRole.USER, content="Pick a letter.")]
+        )
+        result = await language_model(messages, schema=Answer.get_schema())
+        self.assertEqual(result.get_json(), {"answer": "B"})
+
+        # The tool's `parameters` is the whole JSON Schema object, not its
+        # bare property map.
+        tool = mock_completion.call_args.kwargs["tools"][0]["function"]
+        self.assertEqual(tool["name"], "structured_output")
+        self.assertEqual(tool["parameters"]["type"], "object")
+        self.assertIn("answer", tool["parameters"]["properties"])
+        self.assertEqual(
+            mock_completion.call_args.kwargs["tool_choice"]["function"]["name"],
+            "structured_output",
+        )
+
+    @patch("litellm.acompletion")
+    async def test_structured_output_tool_call_wins_over_a_content_preamble(
+        self, mock_completion
+    ):
+        # Some backends behind openrouter narrate before calling the tool.
+        language_model = LanguageModel(model="openrouter/openai/gpt-4o-mini")
+
+        class Answer(DataModel):
+            answer: str
+
+        mock_completion.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "content": "I'll answer with the tool.",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "structured_output",
+                                    "arguments": '{"answer": "true"}',
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+
+        messages = ChatMessages(
+            messages=[ChatMessage(role=ChatRole.USER, content="Yes or no?")]
+        )
+        result = await language_model(messages, schema=Answer.get_schema())
+        self.assertEqual(result.get_json(), {"answer": "true"})
 
     @patch("litellm.acompletion")
     async def test_call_api_streaming_mode(self, mock_completion):
@@ -864,9 +949,7 @@ class FinishReasonTest(testing.TestCase):
     @staticmethod
     def _response(content="", finish_reason="stop"):
         return {
-            "choices": [
-                {"message": {"content": content}, "finish_reason": finish_reason}
-            ]
+            "choices": [{"message": {"content": content}, "finish_reason": finish_reason}]
         }
 
     @patch("litellm.acompletion")
@@ -882,7 +965,9 @@ class FinishReasonTest(testing.TestCase):
     @patch("litellm.acompletion")
     async def test_finish_reason_is_cleared_between_calls(self, mock_completion):
         lm = LanguageModel(model="ollama/mistral")
-        mock_completion.return_value = self._response(content="hi", finish_reason="length")
+        mock_completion.return_value = self._response(
+            content="hi", finish_reason="length"
+        )
         await lm(_chat_messages())
         self.assertEqual(lm.last_call_finish_reason, "length")
         mock_completion.return_value = {"choices": [{"message": {"content": "hi"}}]}
@@ -903,9 +988,7 @@ class FinishReasonTest(testing.TestCase):
         self.assertEqual(lm.last_call_finish_reason, "length")
 
     @patch("litellm.acompletion")
-    async def test_blocked_completion_is_reported_once_not_retried(
-        self, mock_completion
-    ):
+    async def test_blocked_completion_is_reported_once_not_retried(self, mock_completion):
         mock_completion.return_value = self._response(finish_reason="content_filter")
         lm = LanguageModel(model="ollama/mistral", retry=3)
         with warnings.catch_warnings():


### PR DESCRIPTION
## Problem

`LanguageModel` requests structured output from `groq`, `cohere`, `openrouter` and `bedrock` models as a forced `structured_output` tool call (`language_model.py`, the `tools` / `tool_choice` branch in `_prepare_kwargs`), but when the reply comes back only `groq` is read from `tool_calls[0].function.arguments`. Every other provider falls into the generic branch that reads `message["content"]`, which for a forced tool call is `None` or a short preamble. `orjson.loads` then fails, the call is retried `retry` times, and `call()` finally returns `None`.

In practice every `openrouter/...` model scores `None` on structured tasks: an arena evaluating `openrouter/anthropic/claude-opus-4.1` on ARC / BoolQ / GSM8K with `ExactMatch` got `reward=0.0` on every row while paying for ~5 attempts per row (input tokens ≈ 5× a single answer). Nothing surfaced except the retry warnings.

A second, smaller issue in the same branch: the tool's `parameters` was `schema.get("properties")`, a bare property map, where the OpenAI tool format expects a JSON Schema object (`type`, `properties`, `required`, `additionalProperties`).

## Fix

- In `_do_call`, whenever a schema was requested and the reply carries `tool_calls`, read the JSON from `tool_calls[0].function.arguments` (dict arguments are re-serialized), whatever the provider. This keeps the request side and the parse side agreeing on where the JSON lives, and keeps working for groq. Content-based providers (`response_format`) are unchanged.
- Pass the whole `schema` as the tool's `parameters`.

## Tests

Two new cases in `language_model_test.py`, mocking `litellm.acompletion` like the existing ones:

- an `openrouter/...` reply with `content=None` and the JSON in `tool_calls` parses into the schema, and the request carried the full schema as tool `parameters` with `tool_choice` forced;
- a reply with a prose preamble in `content` plus the tool call still parses.

`language_model_test.py`: 39 of 41 pass. The two failures, `MultimodalWireTest::test_audio_dataset_ref_is_resolved_and_stripped_before_send` and `test_image_dataset_ref_is_resolved_before_send`, fail identically on the unmodified base (0.9.15, `7029997`) on Windows: the sample-file path's backslashes make the mocked request body invalid JSON. Unrelated to this change; they pass on POSIX CI. Verified end to end against OpenRouter: `openrouter/openai/gpt-4o-mini` now returns structured output on the first attempt where it previously returned nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hBbFUn1qCFDe4b3PCZiS1
