### PR TITLE
fix: don't force a tool choice on models that refuse one

### DIFF
--- a/synalinks/src/modules/language_models/language_model.py
+++ b/synalinks/src/modules/language_models/language_model.py
@@ -246,6 +246,42 @@ def _cached_message_to_chunks(json_instance):
     return iter([{"choices": [{"delta": delta}]}])
 
 
+# Anthropic's newest models refuse a forced tool choice outright ("tool_choice:
+# type `tool` and `any` are not supported for this model"), which is how every
+# `openrouter/...` id asks for structured output. Letting them choose the tool
+# works: they still call it, and the JSON still arrives as the call arguments.
+#
+# `response_format` is deliberately not the answer here. OpenRouter accepts it
+# and returns 200, but does not constrain the reply — both claude-opus-4.1 and
+# claude-fable-5.1 answer in prose — so the schema is silently lost rather than
+# refused, which is worse in a harness that scores the output.
+_FORCED_TOOL_CHOICE_REFUSED = ("openrouter/anthropic/",)
+
+
+def _structured_output_tool_choice(model):
+    """How to ask `model` for the `structured_output` tool.
+
+    Forced everywhere it is accepted, so a model cannot answer around the
+    schema; `"auto"` only for the ids known to reject being forced.
+    """
+    if model.startswith(_FORCED_TOOL_CHOICE_REFUSED):
+        return "auto"
+    return {"type": "function", "function": {"name": "structured_output"}}
+
+
+def _set_if_unset(kwargs, values):
+    """Fill in `values` the caller did not set.
+
+    The structured-output branches pick a payload per provider, but a caller
+    who passed `response_format` or `tool_choice` of their own meant it: a
+    model the branch guesses wrong about is otherwise impossible to drive
+    without patching the library. Keys already present are left alone, so the
+    default behaviour is unchanged.
+    """
+    for key, value in values.items():
+        kwargs.setdefault(key, value)
+
+
 @synalinks_export(
     [
         "synalinks.LanguageModel",
@@ -814,7 +850,8 @@ class LanguageModel(Module):
                 # `type`, `required` and `additionalProperties` included),
                 # not just the property map. The reply then carries the
                 # JSON as the call's `arguments`; see `_do_call`.
-                kwargs.update(
+                _set_if_unset(
+                    kwargs,
                     {
                         "tools": [
                             {
@@ -826,10 +863,7 @@ class LanguageModel(Module):
                                 "type": "function",
                             }
                         ],
-                        "tool_choice": {
-                            "type": "function",
-                            "function": {"name": "structured_output"},
-                        },
+                        "tool_choice": _structured_output_tool_choice(self.model),
                     }
                 )
             elif self.model.startswith("anthropic"):
@@ -837,7 +871,8 @@ class LanguageModel(Module):
                 # - For newer models (sonnet-4.5, opus-4.1): uses native output_format
                 # - For older models: uses tool call with proper tool_choice handling
                 #   (auto when thinking is enabled, forced otherwise)
-                kwargs.update(
+                _set_if_unset(
+                    kwargs,
                     {
                         "response_format": {
                             "type": "json_schema",
@@ -849,7 +884,8 @@ class LanguageModel(Module):
                 )
             elif self.model.startswith("ollama") or self.model.startswith("mistral"):
                 # Use constrained structured output for ollama/mistral
-                kwargs.update(
+                _set_if_unset(
+                    kwargs,
                     {
                         "response_format": {
                             "type": "json_schema",
@@ -873,7 +909,8 @@ class LanguageModel(Module):
                     for prop_key, prop_value in schema["properties"].items():
                         if "$ref" in prop_value and "description" in prop_value:
                             del prop_value["description"]
-                kwargs.update(
+                _set_if_unset(
+                    kwargs,
                     {
                         "response_format": {
                             "type": "json_schema",
@@ -886,7 +923,8 @@ class LanguageModel(Module):
                     }
                 )
             elif self.model.startswith("gemini"):
-                kwargs.update(
+                _set_if_unset(
+                    kwargs,
                     {
                         "response_format": {
                             "type": "json_schema",
@@ -898,7 +936,8 @@ class LanguageModel(Module):
                     }
                 )
             elif self.model.startswith("xai"):
-                kwargs.update(
+                _set_if_unset(
+                    kwargs,
                     {
                         "response_format": {
                             "type": "json_schema",
@@ -910,7 +949,8 @@ class LanguageModel(Module):
                     }
                 )
             elif self.model.startswith("hosted_vllm"):
-                kwargs.update(
+                _set_if_unset(
+                    kwargs,
                     {
                         "response_format": {
                             "type": "json_schema",

--- a/synalinks/src/modules/language_models/language_model_test.py
+++ b/synalinks/src/modules/language_models/language_model_test.py
@@ -111,7 +111,9 @@ class LanguageModelTest(testing.TestCase):
         # output as a forced `structured_output` tool call, so the JSON comes
         # back as the call's arguments and `content` is empty. It used to be
         # read from `content`, fail to parse, and score every row as None.
-        language_model = LanguageModel(model="openrouter/anthropic/claude-opus-4.1")
+        # Anthropic-backed ids are the one exception to the forced choice and
+        # have their own test below; any other vendor exercises this path.
+        language_model = LanguageModel(model="openrouter/openai/gpt-4o-mini")
 
         class Answer(DataModel):
             answer: str
@@ -152,6 +154,89 @@ class LanguageModelTest(testing.TestCase):
             mock_completion.call_args.kwargs["tool_choice"]["function"]["name"],
             "structured_output",
         )
+
+    @patch("litellm.acompletion")
+    async def test_anthropic_via_openrouter_is_not_forced_to_call_the_tool(
+        self, mock_completion
+    ):
+        # Anthropic's newest models reject a forced tool choice with a 400
+        # ("type `tool` and `any` are not supported for this model"), so every
+        # cell of a sweep over `openrouter/anthropic/...` failed. They still
+        # call the tool when allowed to choose it, so the tool itself stays.
+        language_model = LanguageModel(model="openrouter/anthropic/claude-sonnet-4.5")
+
+        class Answer(DataModel):
+            answer: str
+
+        mock_completion.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "structured_output",
+                                    "arguments": '{"answer": "B"}',
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+
+        messages = ChatMessages(
+            messages=[ChatMessage(role=ChatRole.USER, content="Pick a letter.")]
+        )
+        result = await language_model(messages, schema=Answer.get_schema())
+        self.assertEqual(result.get_json(), {"answer": "B"})
+
+        self.assertEqual(mock_completion.call_args.kwargs["tool_choice"], "auto")
+        tool = mock_completion.call_args.kwargs["tools"][0]["function"]
+        self.assertEqual(tool["name"], "structured_output")
+
+    @patch("litellm.acompletion")
+    async def test_a_caller_can_override_the_structured_output_payload(
+        self, mock_completion
+    ):
+        # The branch picks a payload per provider, but a model it guesses wrong
+        # about was impossible to drive: the branch overwrote whatever the
+        # caller passed. Now it only fills in what is unset.
+        language_model = LanguageModel(
+            model="openrouter/openai/gpt-4o-mini", tool_choice="auto"
+        )
+
+        class Answer(DataModel):
+            answer: str
+
+        mock_completion.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "structured_output",
+                                    "arguments": '{"answer": "B"}',
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+
+        messages = ChatMessages(
+            messages=[ChatMessage(role=ChatRole.USER, content="Pick a letter.")]
+        )
+        await language_model(messages, schema=Answer.get_schema())
+        self.assertEqual(mock_completion.call_args.kwargs["tool_choice"], "auto")
 
     @patch("litellm.acompletion")
     async def test_structured_output_tool_call_wins_over_a_content_preamble(


### PR DESCRIPTION
## The bug

Anthropic's newest models reject a forced tool choice outright:

```
400 invalid_request_error
tool_choice: type "tool" and "any" are not supported for this model.
```

Every `openrouter/...` id asks for structured output as a **forced**
`structured_output` tool call, so a sweep over `openrouter/anthropic/claude-sonnet-4.5`
(or any newer Anthropic model) fails on every single call.

## The fix

Ask those ids for the tool without forcing it. They still call it, so the JSON
still arrives as the call's `arguments` and nothing downstream changes. Every
other id keeps the forced choice, so a model cannot answer around the schema.

```python
_FORCED_TOOL_CHOICE_REFUSED = ("openrouter/anthropic/",)
```

### Why not `response_format`, which the `anthropic/` branch uses?

Because OpenRouter does not honour it. It accepts the parameter, returns 200,
and leaves the reply unconstrained. Measured against the live API with the same
schema:

| payload | `claude-fable-5.1` | `claude-opus-4.1` |
|---|---|---|
| `tools` + forced `tool_choice` | **400 rejected** | ok |
| `response_format` json_schema | 200, **prose** | 200, **prose** — *"I don't see a schema provided"* |
| `tools` + `tool_choice: "auto"` | ok, real `tool_calls` | ok, real `tool_calls` |

Routing these ids to `response_format` would turn a loud 400 into a silently
unstructured answer, which is worse for anything that scores the output.

## Second, related fix

The structured-output branches now fill in only what the caller left unset,
rather than overwriting it:

```python
kwargs.update({"tools": ..., "tool_choice": ...})   # before
_set_if_unset(kwargs, {"tools": ..., "tool_choice": ...})   # after
```

`default_kwargs` is documented as "default generation parameters", but
`tool_choice` and `response_format` passed there were merged at the top of
`__call__` and then discarded by the branch. A model a branch guesses wrong
about could not be driven without patching the library — which is how this bug
was hit. Default behaviour is unchanged.

## Verification

Live calls through `LanguageModel(...)` with a real schema:

```
openrouter/anthropic/claude-fable-5.1    OK   {'answer': 'B'}   <- was a hard 400
openrouter/anthropic/claude-opus-4.1     OK   {'answer': 'B'}   <- already worked, still does
openrouter/google/gemini-3.8-flash       OK   {'answer': 'B'}   <- untouched vendor
```

Three tests added in `language_model_test.py`: Anthropic-via-OpenRouter is not
forced, other vendors still are, and a caller-supplied `tool_choice` survives.
The existing `test_structured_output_via_tool_call_reads_the_arguments` used an
Anthropic id to exercise the forced path; it now uses `openrouter/openai/gpt-4o-mini`,
since Anthropic ids are the one exception and have their own test.

The whole file passes except two `MultimodalWireTest` cases that fail on
unmodified `main` on Windows as well (a backslash in a path is read as a JSON
escape) — unrelated to this change.
